### PR TITLE
Refactor pipelines to use common code, added dither combination and improved background subtraction

### DIFF
--- a/jwst_summary_plots.py
+++ b/jwst_summary_plots.py
@@ -255,9 +255,15 @@ def make_summary_plot(
         vmax=np.nanpercentile(img, vmax_percentile),
     )
 
+    if 'dither-combined' in primary_header['ASNTABLE']:
+        # Dither combinations still have PATT_NUM = 1, so use asn filename as flag
+        dither = 'combined'
+    else:
+        dither = primary_header['PATT_NUM']
+
     title_parts = [
         primary_header['TARGPROP'],
-        'Dither {}'.format(primary_header['PATT_NUM']),
+        f'Dither {dither}',
         primary_header['INSTRUME'],
     ]
     if instrument == 'MIRI':

--- a/jwst_summary_plots.py
+++ b/jwst_summary_plots.py
@@ -77,6 +77,8 @@ DATA_CMAP = 'plasma'
 SATURATION_CMAP = 'YlOrRd'
 SATURATION_COLOR = 'r'
 
+# TODO make sp_max auto by default?
+
 
 def main(p_in, p_out):
     make_summary_plot(p_in, p_out)
@@ -298,7 +300,7 @@ def make_summary_plot(
     sp_max = sp_fn(data[:, data_to_use], axis=1)
 
     if plot_brightest_spectrum:
-        ax.plot(wl, sp_max, color='tab:blue', linewidth=1)
+        ax.plot(wl, sp_max, color='tab:blue', alpha=0.667, linewidth=1)
     ax.plot(wl, sp, color='k', linewidth=1)
     if plot_brightest_spectrum:
         for s, c in [

--- a/jwst_summary_plots.py
+++ b/jwst_summary_plots.py
@@ -88,7 +88,7 @@ def make_summary_plot(
     show: bool = False,
     vmin_percentile: float = 0,
     vmax_percentile: float = 100,
-    plot_brightest_spectrum: bool = True,
+    plot_brightest_spectrum: bool = False,
 ):
     """
     Create and save a summary plot of a JWST observation.
@@ -111,6 +111,8 @@ def make_summary_plot(
             `'.png'` in the input path. If the output directory does not exist, it will
             automatically be created.
         show: Toggle to optionally show the plot instead of saving it.
+        plot_brightness_spectrum: Toggle to optionally plot the spectrum of the brightest
+            10% of spaxels in the cube in addition to the average spectrum.
     """
     fig = plt.figure(figsize=(10, 10), dpi=200)
 

--- a/jwst_summary_plots.py
+++ b/jwst_summary_plots.py
@@ -88,7 +88,7 @@ def make_summary_plot(
     show: bool = False,
     vmin_percentile: float = 0,
     vmax_percentile: float = 100,
-    plot_brightest_spectrum: bool = False,
+    plot_brightest_spectrum: bool = True,
 ):
     """
     Create and save a summary plot of a JWST observation.
@@ -136,9 +136,9 @@ def make_summary_plot(
         else:
             lon_img = hdul['LON'].data  # type: ignore
 
-        if primary_header.get('S_BKGSUB'):
+        if primary_header.get('S_BKDSUB') == 'COMPLETE':
             reduction_notes.append('Background subtracted')
-        if primary_header.get('S_RESFRI'):
+        if primary_header.get('S_RESFRI') == 'COMPLETE':
             reduction_notes.append('Residual fringe corrected')
         reduction_notes.extend(get_header_reduction_notes(hdul))
     instrument = primary_header['INSTRUME']
@@ -326,7 +326,7 @@ def make_summary_plot(
         ax.set_ylabel(ax.get_ylabel() + ' (linear scale)')
     else:
         ax.set_yscale('log')
-    if instrument == 'NIRSPEC':
+    if instrument == 'NIRSPEC' or ax.get_ylim()[0] < 0.5:
         ylim = ax.get_ylim()
         ymin = max(
             ylim[0], min(max(np.nanpercentile(sp, 5) / 10, 5e-2), np.nanmin(sp_max))

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -175,7 +175,7 @@ python3 miri_pipeline.py /data/uranus/lon1 --start_step plot --end_step plot
 python3 miri_pipeline.py /data/uranus/lon1 --start_step desaturate
 
 # Run the pipeline, passing custom arguments to different steps
-python3 miri_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "animation": {"radius_factor": 2.5}}'
+python3 miri_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "plot": {"plot_brightest_spectrum": true}, "animation": {"radius_factor": 2.5}}'
 """
 
 import argparse
@@ -343,6 +343,7 @@ def run_pipeline(
             stage3_kwargs={
                 'outlier_detection': {'snr': '30.0 24.0', 'scale': '1.3 0.7'}
             },
+            plot_kwargs={'plot_brightest_spectrum': True},
             animation_kwargs={'radius_factor': 2.5},
         )
 

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -73,6 +73,23 @@ If the pipeline is run with desaturation enabled, the pipeline flow is:
   desaturated dataset.
 - Subsequent pipeline steps (e.g. `plot`) are run on the desaturated data.
 
+Data cubes are saved at each step of the pipeline, with the data in each stage directory
+used as the input for the next stage. The `stage0`, `stage1` and `stage2` directories
+contain partially reduced data cubes. The `stage3` directory onwards contain reduced 
+data cubes which can be used for science. Within each science directory (`stage3`, 
+`stage4...` etc.), files are organised by dither and any data variant. For example:
+- `stage3/d1` contains the stage3 data for dither 1
+- `stage3/d2_bg` contains the stage3 data for dither 2 with the background subtracted
+- `stage3/d2_bg_fringe` contains the stage3 data for dither 2 with the background
+   subtracted and the residual fringes step run on the data
+- `stage3/combined` contains the stage4 data with all dithers combined
+- `stage4_flat/d3` contains the stage4 for dither 3
+
+The `plots` and `animation` directories contain quick look visualisations of the data.
+
+Metadata about the pipeline processing steps is saved in the `PRIMARY` FITS header of 
+each file.
+
 For more command line examples, see CLI_EXAMPLES below, and for more Python examples,
 see the docstring for `run_pipeline()` below.
 

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -7,6 +7,8 @@ visualisation.
 
 See STEP_DESCRIPTIONS below for a description of each step in this pipeline.
 
+GitHub repository: https://github.com/JWSTGiantPlanets/pipelines
+
 
 Setup
 =====
@@ -44,28 +46,29 @@ Usage
 =====
 The pipeline can be run from the command line, or imported and run from Python. To run
 the pipeline to fully reduce a dataset, simply download the stage0 (e.g. to 
-`/data/saturn/SATURN-15N/stage0`), then run the following command on the command line ::
+`/data/uranus/lon1/stage0`), then run the following command on the command line ::
 
-    python3 miri_pipeline.py /data/saturn/SATURN-15N
+    python3 miri_pipeline.py /data/uranus/lon1
 
 or from Python ::
 
     import miri_pipeline
-    miri_pipeline.run_pipeline('/data/saturn/SATURN-15N')
+    miri_pipeline.run_pipeline('/data/uranus/lon1')
 
 This will run the full pipeline, and output data files appropriate directories (e.g. 
-`/data/saturn/SATURN-15N/stage3`, `/data/saturn/SATURN-15N/plots` etc.).
+`/data/uranus/lon1/stage3`, `/data/uranus/lon1/plots` etc.).
 
-By default, the full pipeline is effectively run twice, first with the redisdual 
-defringe step disabled, then with it enabled. If you only want defringed or 
-non-defringed data, you can customise this behaviour with the `defringe` argument or the
-`--defringe` or `--no-defringe` flags.
+By default, most steps of the pipeline are effectively run twice, each step with the 
+redisdual defringe step disabled first, then with it enabled. If you only want defringed
+or non-defringed data, you can customise this behaviour with the `defringe` argument or 
+the `--defringe` or `--no-defringe` flags.
 
 If the pipeline is run with desaturation enabled, the pipeline flow is:
 - Firstly, multiple versions of the stage0 cubes are greated with different numbers of 
   groups (the `remove_groups` step).
-- The `reduction` and `navigation` steps are run on e.g. the 4 group data, then the
-  3 group data, then the 2 group data, then the 1 group data.
+- `stage1` is run on e.g. the 4 group data, then the 3 group data, then the 2 group
+  data, then the 1 group data. Then `stage2` is run on the 4-1 group data, then 
+  `stage3`, then `navigate`.
 - The `desaturate` step is then run to combine the various group data into a single
   desaturated dataset.
 - Subsequent pipeline steps (e.g. `plot`) are run on the desaturated data.
@@ -103,12 +106,12 @@ etc., you may need to increase the walltime and decrease the number of nodes (pp
 
 To use this script you will need to:
 - replace `py310` in the `conda activate` line to the name of your conda environment
-- replace the two references to `/data/.../SATURN-15N` with the path to your data :: 
+- replace the two references to `/data/uranus/lon1` with the path to your data :: 
 
     #!/bin/bash
     #
     #PBS -N MIRI_Pipeline
-    #PBS -l walltime=18:00:00
+    #PBS -l walltime=24:00:00
     #PBS -l vmem=80gb
     #PBS -l nodes=1:ppn=8
     
@@ -125,15 +128,18 @@ To use this script you will need to:
     fi
 
     # Run the pipeline
-    python3 /data/nemesis/jwst/scripts/oliver/pipelines/miri_pipeline.py /data/nemesis/jwst/MIRI_IFU/Saturn_2022nov13/SATURN-15N --parallel
+    python3 /data/nemesis/jwst/scripts/oliver/pipelines/miri_pipeline.py /data/uranus/lon1 --parallel
     
     # Change permissions on modified files so that other users can use them
-    chmod -R --quiet 777 /data/nemesis/jwst/MIRI_IFU/Saturn_2022nov13/SATURN-15N
+    chmod -R --quiet 777 /data/uranus/lon1
     chmod -R --quiet 777 $CRDS_PATH
 """
 STEP_DESCRIPTIONS = """
 - `remove_groups`: Remove groups from the data (for use in desaturating the data) [optional].
-- `reduction`: Run the standard JWST reduction pipeline (stage0 to stage3).
+- `stage1`: Run the standard JWST reduction pipeline stage 1.
+- `stage2`: Run the standard JWST reduction pipeline stage 2.
+- `defringe`: Run thhe JWST reduction pipeline residual fringe step [optional].
+- `stage3`: Run the standard JWST reduction pipeline stage 3.
 - `navigate`: Navigate reduced files.
 - `desaturate`: Desaturate data using cubes with fewer groups [optional].
 - `flat`: Correct flat effects using synthetic flat field cubes.
@@ -148,36 +154,43 @@ CLI_EXAMPLES = """examples:
 python3 miri_pipeline.py -h
 
 # Run the full pipeline, with all steps enabled
-python3 miri_pipeline.py /data/saturn/SATURN-15N
+python3 miri_pipeline.py /data/uranus/lon1
 
 # Run the full pipeline, without any desaturation
-python3 miri_pipeline.py /data/saturn/SATURN-15N --no-desaturate
+python3 miri_pipeline.py /data/uranus/lon1 --no-desaturate
 
 # Run the full pipeline, with only the defringed data
-python3 miri_pipeline.py /data/saturn/SATURN-15N --defringe
+python3 miri_pipeline.py /data/uranus/lon1 --defringe
 
 # Run the pipeline, including background subtraction
-python3 miri_pipeline.py /data/saturn/SATURN-15N --background_path /data/saturn/SATURN-BACKGROUND
+python3 miri_pipeline.py /data/uranus/lon1 --background_path /data/saturn/SATURN-BACKGROUND
 
 # Run the pipeline, but stop before creating any visualisations
-python3 miri_pipeline.py /data/saturn/SATURN-15N --end_step despike
+python3 miri_pipeline.py /data/uranus/lon1 --end_step despike
 
 # Only run the plotting step
-python3 miri_pipeline.py /data/saturn/SATURN-15N --start_step plot --end_step plot
+python3 miri_pipeline.py /data/uranus/lon1 --start_step plot --end_step plot
 
 # Re-run the pipeline, skipping the initial reduction steps
-python3 miri_pipeline.py /data/saturn/SATURN-15N --start_step desaturate
+python3 miri_pipeline.py /data/uranus/lon1 --start_step desaturate
 
 # Run the pipeline, passing custom arguments to different steps
-python3 miri_pipeline.py /data/saturn/SATURN-RINGS --kwargs '{"reduction": {"stages": [2, 3]}, "animation": {"radius_factor": 2.5}}'
+python3 miri_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "animation": {"radius_factor": 2.5}}'
 """
+
 import argparse
 import glob
 import json
 import os
+import pathlib
 from typing import Any, Literal, TypeAlias
 
 import tqdm
+from astropy.io import fits
+from jwst.associations.asn_from_list import asn_from_list
+from jwst.associations.lib.rules_level3_base import DMS_Level3_Base
+from jwst.pipeline import Detector1Pipeline, Spec2Pipeline, Spec3Pipeline
+from jwst.residual_fringe import ResidualFringeStep
 
 import background_subtraction
 import desaturate_data
@@ -186,36 +199,39 @@ import flat_field
 import jwst_summary_animation
 import jwst_summary_plots
 import navigate_jwst_observations
-import reduce_jwst_miri
 import remove_groups
 from parallel_tools import runmany
-from tools import KeepMissingDict, all_combinations, log
+from tools import check_path, log
 
-# Central record of the filepaths for various steps of the reduction pipeline
-PATH_FITS = os.path.join(
-    '{stage}',
-    'd{dither}{fringe}{nav}',
-    'Level3_ch{channel}-{band}_s3d{nav}.fits',
-)
-PATH_PLOT = os.path.join(
-    'plots',
-    '{stage}',
-    'd{dither}{fringe}',
-    '{channel}{abc}-Level3_ch{channel}-{band}_s3d.png',
-)
-PATH_ANIMATION = os.path.join(
-    'animation',
-    '{stage}',
-    'dither_comparison{fringe}',
-    '{channel}{abc}_animation.mp4',
-)
-PATH_STAGE3_RAW = PATH_FITS.format_map(KeepMissingDict(stage='stage3', nav=''))
-PATH_DATA = PATH_FITS.format_map(KeepMissingDict(nav='_nav'))
-PATH_NAVIGATED = PATH_DATA.format_map(KeepMissingDict(stage='stage3'))
-PATH_DESATURATED = PATH_DATA.format_map(KeepMissingDict(stage='stage3_desaturated'))
-PATH_FLAT = PATH_DATA.format_map(KeepMissingDict(stage='stage4_flat'))
-PATH_DESPIKED = PATH_DATA.format_map(KeepMissingDict(stage='stage5_despike'))
-PATH_BACKGROUND = PATH_DATA.format_map(KeepMissingDict(stage='stage6_background'))
+# Pipeline constants
+Step: TypeAlias = Literal[
+    'remove_groups',
+    'stage1',
+    'stage2',
+    'defringe',
+    'stage3',
+    'navigate',
+    'desaturate',
+    'flat',
+    'despike',
+    'background',
+    'plot',
+    'animate',
+]
+STEPS: list[Step] = [
+    'remove_groups',
+    'stage1',
+    'stage2',
+    'defringe',
+    'stage3',
+    'navigate',
+    'desaturate',
+    'flat',
+    'despike',
+    'background',
+    'plot',
+    'animate',
+]
 
 DATA_STAGES = [
     'stage3',
@@ -241,35 +257,30 @@ for _p in _path_options:
         DEFAULT_FLAT_DATA_PATH = os.path.normpath(_p)
         break
 
-# Arguments to format the paths above
-CHANNELS = ['1', '2', '3', '4']
-BANDS = ['short', 'medium', 'long']
-FRINGES = ['', '_fringe']
-CHANNEL_LENGTH_ALIASES = {'short': 'A', 'medium': 'B', 'long': 'C'}
+MIRI_BAND_ABC_ALIASES = {'short': 'A', 'medium': 'B', 'long': 'C'}
 
-# Pipeline constants
-Step: TypeAlias = Literal[
-    'remove_groups',
-    'reduce',
-    'navigate',
-    'desaturate',
-    'flat',
-    'despike',
-    'background',
-    'plot',
-    'animate',
-]
-STEPS: list[Step] = [
-    'remove_groups',
-    'reduce',
-    'navigate',
-    'desaturate',
-    'flat',
-    'despike',
-    'background',
-    'plot',
-    'animate',
-]
+# Default arguments for each step. These are merged with the user-supplied kwargs
+# before being passed to the pipeline, for example:
+# stage1_kwargs = DEFAULT_STAGE1_KWARGS | stage1_kwargs
+DEFAULT_STAGE1_KWARGS = {}
+DEFAULT_STAGE2_KWARGS = {
+    'steps': {'cube_build': {'skip': True}, 'extract_1d': {'skip': True}}
+}
+DEFAULT_DEFRINGE_KWARGS = {}
+DEFAULT_STAGE3_KWARGS = {
+    'steps': {
+        'master_background': {'skip': True},
+        'extract_1d': {'skip': True},
+        'cube_build': {'output_type': 'band', 'coord_system': 'ifualign'},
+    }
+}
+DEFAULT_DESATURATE_KWARGS = {}
+DEFAULT_NAVIGATE_KWARGS = {}
+DEFAULT_FLAT_KWARGS = {}
+DEFAULT_DESPIKE_KWARGS = {}
+DEFAULT_BACKGROUND_KWARGS = {}
+DEFAULT_PLOT_KWARGS = {}
+DEFAULT_ANIMATE_KWARGS = {}
 
 
 def run_pipeline(
@@ -279,21 +290,25 @@ def run_pipeline(
     desaturate: bool = True,
     groups_to_use: list[int] | None = None,
     background_path: str | None = None,
-    ndither: int = 4,
     parallel: float | bool = False,
     flat_data_path: str = DEFAULT_FLAT_DATA_PATH,
     basic_navigation: bool = False,
     skip_steps: list[Step] | set[Step] | None = None,
     start_step: Step | None = None,
     end_step: Step | None = None,
-    reduction_kwargs: dict[str, Any] | None = None,
-    navigation_kwargs: dict[str, Any] | None = None,
-    desaturation_kwargs: dict[str, Any] | None = None,
+    stage1_kwargs: dict[str, Any] | None = None,
+    stage2_kwargs: dict[str, Any] | None = None,
+    defringe_kwargs: dict[str, Any] | None = None,
+    stage3_kwargs: dict[str, Any] | None = None,
+    navigate_kwargs: dict[str, Any] | None = None,
+    desaturate_kwargs: dict[str, Any] | None = None,
     flat_kwargs: dict[str, Any] | None = None,
     despike_kwargs: dict[str, Any] | None = None,
     background_kwargs: dict[str, Any] | None = None,
     plot_kwargs: dict[str, Any] | None = None,
-    animation_kwargs: dict[str, Any] | None = None,
+    animate_kwargs: dict[str, Any] | None = None,
+    parallel_kwargs: dict[str, Any] | None = None,
+    reduction_parallel_kwargs: dict[str, Any] | None = None,
 ) -> None:
     """
     Run the full MIRI MRS reduction pipeline, including the standard reduction from
@@ -305,27 +320,29 @@ def run_pipeline(
         from miri_pipeline import run_pipeline
 
         # Run the full pipeline, with all steps enabled
-        run_pipeline('/data/saturn/SATURN-15N')
+        run_pipeline('/data/uranus/lon1')
 
         # Run the full pipeline, without any desaturation
-        run_pipeline('/data/saturn/SATURN-15N', desaturate=False)
+        run_pipeline('/data/uranus/lon1', desaturate=False)
 
         # Run the pipeline, including background subtraction
         run_pipeline(
-            '/data/saturn/SATURN-15N',
-            background_path='data/saturn/SATURN-BACKGROUND',
+            '/data/uranus/lon1',
+            background_path='data/uranus/background',
         )
 
         # Run the pipeline, but stop before creating any visualisations
-        run_pipeline('/data/saturn/SATURN-15N', end_step='despike')
+        run_pipeline('/data/uranus/lon1', end_step='despike')
 
         # Re-run the pipeline, skipping the initial reduction steps
-        run_pipeline('/data/saturn/SATURN-15N', start_step='desaturate')
+        run_pipeline('/data/uranus/lon1', start_step='desaturate')
 
         # Run the pipeline, passing custom arguments to different steps
         run_pipeline(
-            '/data/saturn/SATURN-RINGS',
-            reduction_kwargs={'stages': [2, 3]},
+            '/data/uranus/lon1',
+            stage3_kwargs={
+                'outlier_detection': {'snr': '30.0 24.0', 'scale': '1.3 0.7'}
+            },
             animation_kwargs={'radius_factor': 2.5},
         )
 
@@ -350,12 +367,11 @@ def run_pipeline(
             `desaturate` is False, then this argument will be ignored. The data with all
             groups will always be included.
         background_path: Path to directory containing background data. For example, if
-            your `root_path` is `/data/saturn/SATURN-15N`, the `background_path` may
-            be `/data/saturn/SATURN-BACKGROUND`. Note that background subtraction will
+            your `root_path` is `/data/uranus/lon1`, the `background_path` may
+            be `/data/uranus/background`. Note that background subtraction will
             require the background data to be already reduced. If no `background_path`
             is specified (the default), then no background subtraction will be
             performed.
-        ndither: Number of dithers for each observation. Defaults to 4.
         parallel: Fraction of CPU cores to use when multiprocessing. Set to 0 to run
             serially, 1 to use all cores, 0.5 to use half of the cores, etc. If enabled,
             multiprocessing is used in the `reduction`, `despike`, `plot` and `animate`
@@ -377,12 +393,33 @@ def run_pipeline(
         end_step: Convenience argument to add all steps after `end_step` to
             `skip_steps`.
 
-        reduction_kwargs, navigation_kwargs, desaturation_kwargs, flat_kwargs,
-        despike_kwargs, spx_kwargs, plot_kwargs, animation_kwargs: Arguments are passed
-            to the corresponding functions for each step of the pipeline. These can
-            therefore be used to override the default values for each step. See the
-            documentation for each function for details on the arguments.
+        stage1_kwargs, stage2_kwargs, defringe_kwargs, stage3_kwargs, desaturate_kwargs,
+        navigate_kwargs, flat_kwargs, despike_kwargs, plot_kwargs, animate_kwargs:
+            Dictionaries of arguments passed to the corresponding functions for each
+            step of the pipeline. These can therefore be used to override the default
+            values for each step. See the documentation for each function for details on
+            the arguments. See the constants (e.g. DEFAULT_STAGE1_KWARGS) above for the
+            default values.
     """
+    # Process args
+    parallel_kwargs = dict(
+        parallel_frac=parallel,
+        timeout=60 * 60,
+    ) | (parallel_kwargs or {})
+    reduction_parallel_kwargs = (
+        parallel_kwargs
+        | dict(
+            start_delay=10,
+            parallel_job_kw=dict(
+                caught_error_wait_time=15,
+                caught_error_wait_time_frac=1,
+                caught_error_wait_time_max=600,
+            ),
+        )
+        | (reduction_parallel_kwargs or {})
+    )
+
+    # Process skip steps
     if skip_steps is None:
         skip_steps = []
     for s in skip_steps:
@@ -399,7 +436,6 @@ def run_pipeline(
         if end_step not in STEPS:
             raise ValueError(f'Invalid end step: {end_step!r} (valid steps: {STEPS})')
         skip_steps.update(STEPS[STEPS.index(end_step) + 1 :])
-
     if basic_navigation:
         skip_steps.add('animate')
 
@@ -409,6 +445,7 @@ def run_pipeline(
         background_path = os.path.expandvars(os.path.expanduser(background_path))
     flat_data_path = os.path.expandvars(os.path.expanduser(flat_data_path))
 
+    # Print info
     log('Running MIRI pipeline')
     log(f'Root path: {root_path!r}', time=False)
     if skip_steps:
@@ -424,66 +461,90 @@ def run_pipeline(
         log(f'Groups to keep: {groups_to_use!r}', time=False)
     if basic_navigation:
         log(f'Basic navigation: {basic_navigation!r}', time=False)
-    log(f'Number of dithers: {ndither!r}', time=False)
     print()
 
-    if defringe == 'both':
-        kwargs = dict(
-            desaturate=desaturate,
-            groups_to_use=groups_to_use,
-            background_path=background_path,
-            ndither=ndither,
-            parallel=parallel,
-            flat_data_path=flat_data_path,
-            basic_navigation=basic_navigation,
-            navigation_kwargs=navigation_kwargs,
-            desaturation_kwargs=desaturation_kwargs,
-            flat_kwargs=flat_kwargs,
-            despike_kwargs=despike_kwargs,
-            background_kwargs=background_kwargs,
-            plot_kwargs=plot_kwargs,
-            animation_kwargs=animation_kwargs,
-        )
-
-        # First, run the entire pipeline with defringe=False
-        # (do defringe=False first as it is much faster)
-        run_pipeline(
-            root_path,
-            defringe=False,
-            skip_steps=skip_steps,
-            reduction_kwargs=reduction_kwargs,
-            **kwargs,
-        )
-
-        # Then run the pipeline from the defringe step onwards with defringe=True
-        # (no need to run the remove groups and reduction stages 1&2 again)
-        skip_steps |= {'remove_groups'}
-        reduction_kwargs = reduction_kwargs or {}
-        reduction_kwargs.setdefault('stages', [2.5, 3])
-        run_pipeline(
-            root_path,
-            defringe=True,
-            skip_steps=skip_steps,
-            reduction_kwargs=reduction_kwargs,
-            **kwargs,
-        )
-
-        log('MIRI pipeline completed for both defringe settings')
-        print()
-        return
-
     # Run pipeline steps...
-
     if desaturate and 'remove_groups' not in skip_steps:
-        log('Removing groups from data...')
-        files = sorted(glob.glob(os.path.join(root_path, 'stage0', '*.fits')))
-        # Allow customisation of remove_groups() groups_to_use argument with kwargs
-        kw = {**dict(groups_to_use=groups_to_use), **(desaturation_kwargs or {})}
-        for _p in tqdm.tqdm(files, desc='Removing groups'):
-            remove_groups.remove_groups_from_file(_p, **kw)
-        log('Remove groups step complete\n')
+        run_remove_groups(root_path, groups_to_use)
 
     # Create list of paths to reduce (both 'main' dataset and reduced groups)
+    group_root_paths = get_group_root_paths(root_path, desaturate, groups_to_use)
+    defringe_options = [False, True] if defringe == 'both' else [defringe]
+
+    if 'stage1' not in skip_steps:
+        run_stage1(group_root_paths, stage1_kwargs, reduction_parallel_kwargs)
+
+    if 'stage2' not in skip_steps:
+        run_stage2(group_root_paths, stage2_kwargs, reduction_parallel_kwargs)
+
+    if defringe and 'defringe' not in skip_steps:
+        run_defringe(group_root_paths, defringe_kwargs, parallel_kwargs)
+
+    if 'stage3' not in skip_steps:
+        run_stage3(
+            group_root_paths, defringe_options, stage3_kwargs, reduction_parallel_kwargs
+        )
+
+    if 'navigate' not in skip_steps:
+        run_navigate(
+            group_root_paths, defringe_options, basic_navigation, navigate_kwargs
+        )
+
+    if desaturate and 'desaturate' not in skip_steps:
+        run_desaturate(
+            root_path,
+            group_root_paths,
+            defringe_options,
+            desaturate_kwargs,
+            parallel_kwargs,
+        )
+
+    if 'flat' not in skip_steps:
+        run_flat(
+            root_path,
+            defringe_options,
+            flat_data_path,
+            flat_kwargs,
+            input_stage='stage3_desaturated' if desaturate else 'stage3',
+        )
+
+    if 'despike' not in skip_steps:
+        run_despike(root_path, defringe_options, despike_kwargs, parallel_kwargs)
+
+    if background_path is not None and 'background' not in skip_steps:
+        run_background(root_path, defringe_options, background_path, background_kwargs)
+
+    if 'plot' not in skip_steps:
+        run_plot(group_root_paths, defringe_options, plot_kwargs, parallel_kwargs)
+
+    if 'animate' not in skip_steps:
+        run_animate(root_path, defringe_options, animate_kwargs, parallel_kwargs)
+
+    log('MIRI pipeline completed with')
+    log(f'Root path: {root_path!r}', time=False)
+    log(f'Defringe: {defringe!r}', time=False)
+    log(f'Desaturate: {desaturate!r}', time=False)
+    if skip_steps:
+        log(
+            f'Skipped steps: {", ".join([repr(s) for s in STEPS if s in skip_steps])}',
+            time=False,
+        )
+    log('ALL DONE')
+
+
+# remove groups
+def run_remove_groups(root_path: str, groups_to_use: list[int] | None = None) -> None:
+    log('Removing groups')
+    paths_in = sorted(glob.glob(os.path.join(root_path, 'stage0', '*_uncal.fits')))
+    log(f'Processing {len(paths_in)} files...', time=False)
+    for p in tqdm.tqdm(paths_in, desc='remove_groups'):
+        remove_groups.remove_groups_from_file(p, groups_to_use)
+    log('Remove groups step complete\n')
+
+
+def get_group_root_paths(
+    root_path: str, desaturate: bool, groups_to_use: list[int] | None = None
+) -> list[str]:
     group_root_paths = [root_path]
     if desaturate:
         # If desaturating, we also need to reduce the data with fewer groups
@@ -501,236 +562,551 @@ def run_pipeline(
                 if int(os.path.basename(_p).split('_')[0]) in groups_to_use
             ]
         group_root_paths.extend(reduced_group_root_paths)
+    return group_root_paths
 
-    if 'reduce' not in skip_steps:
-        log('Reducing data...')
-        for _p in group_root_paths:
-            # Allow customisation of reduction parallel kw with reduction_kwargs
-            kw = {**dict(parallel=parallel), **(reduction_kwargs or {})}
-            reduce_jwst_miri.JWSTReduction(
-                _p,
-                defringe=defringe,
-                _run_immediately=True,
-                **kw,
-            )
-        log('Reduction step complete\n')
 
-    if 'navigate' not in skip_steps:
-        log('Navigating data...')
-        paths_to_navigate = []
-        for _p in group_root_paths:
-            paths_to_navigate.extend(
-                get_stage_paths(_p, PATH_STAGE3_RAW, defringe, ndither)
-            )
-        paths_to_navigate = [_p for _p in paths_to_navigate if os.path.exists(_p)]
-        navigate_jwst_observations.load_kernels()
-        navigate_jwst_observations.navigate_multiple(
-            *paths_to_navigate, basic=basic_navigation, **navigation_kwargs or {}
-        )
-        log('Navigation step complete\n')
-
-    if desaturate and 'desaturate' not in skip_steps:
-        log('Desaturating data...')
-        paths_in_list = [
-            get_stage_paths(_p, PATH_NAVIGATED, defringe, ndither)
-            for _p in group_root_paths
-        ]
-        paths_out = get_stage_paths(root_path, PATH_DESATURATED, defringe, ndither)
-        args_list = []
-        for paths_in, path_out in zip(zip(*paths_in_list), paths_out):
-            if os.path.exists(paths_in[0]):
-                args_list.append((paths_in, path_out))
-
-        log(f'Processing {len(args_list)} files...')
-        for paths_in, paths_out in tqdm.tqdm(args_list, desc='Desaturating'):
-            desaturate_data.replace_saturated(
-                paths_in, paths_out, **desaturation_kwargs or {}
-            )
-        log('Desaturation step complete\n')
-
-    if 'flat' not in skip_steps:
-        log('Applying flat fields...')
-        pattern_in = PATH_DESATURATED if desaturate else PATH_NAVIGATED
-        log(f'Input file pattern: {pattern_in!r}', time=False)
-        log(f'Flat data path: {flat_data_path!r}', time=False)
-        paths = [
-            (p_in, p_out, p_flat)
-            for p_in, p_out, p_flat in zip(
-                get_stage_paths(root_path, pattern_in, defringe, ndither),
-                get_stage_paths(root_path, PATH_FLAT, defringe, ndither),
-                get_stage_paths(None, flat_data_path, defringe, ndither),
-            )
-            if os.path.exists(p_in)
-        ]
-
-        log(f'Processing {len(paths)} files...')
-        for p_in, p_out, p_flat in tqdm.tqdm(paths, desc='Flat fielding'):
-            flat_field.apply_flat(p_in, p_out, p_flat, **flat_kwargs or {})
-        log('Flat fielding step complete\n')
-
-    if 'despike' not in skip_steps:
-        log('Despiking data...')
-        paths = [
-            (p_in, p_out)
-            for p_in, p_out in zip(
-                get_stage_paths(root_path, PATH_FLAT, defringe, ndither),
-                get_stage_paths(root_path, PATH_DESPIKED, defringe, ndither),
-            )
-            if os.path.exists(p_in)
-        ]
-
-        log(f'Processing {len(paths)} files...')
-        if parallel:
-            despike_kwargs = despike_kwargs or {}
-            despike_kwargs['progress_bar'] = False
-        despike_args = [(p_in, p_out, despike_kwargs) for p_in, p_out in paths]
-        runmany(despike_fn, despike_args, parallel_frac=parallel, desc='Despiking')
-        log('Despiking step complete\n')
-
-    if (background_path is not None) and ('background' not in skip_steps):
-        log('Subtracting background...')
-        log(f'Background path: {background_path!r}', time=False)
-        paths = [
-            (p_in, p_out, p_bg)
-            for p_in, p_out, p_bg in zip(
-                get_stage_paths(root_path, PATH_DESPIKED, defringe, ndither),
-                get_stage_paths(root_path, PATH_BACKGROUND, defringe, ndither),
-                get_stage_paths(
-                    background_path,
-                    PATH_DESPIKED.format_map(KeepMissingDict(dither='1')),
-                    defringe,
-                    ndither,
-                ),
-            )
-            if os.path.exists(p_in) and os.path.exists(p_bg)
-        ]
-        log(f'Processing {len(paths)} files...')
-        for p_in, p_out, p_bg in tqdm.tqdm(paths, desc='Background subtracting'):
-            background_subtraction.subtract_background(
-                p_in, p_out, p_bg, **flat_kwargs or {}
-            )
-        log('Background step complete\n')
-
-    if 'plot' not in skip_steps:
-        log('Generating quick look plots...')
-        # Reverse stages so that we get plots of the 'final' version generated first
-        for stage in reversed(DATA_STAGES):
-            log(f'Generating plots for stage {stage}...')
-            template_in = PATH_DATA.format_map(KeepMissingDict(stage=stage))
-            template_out = PATH_PLOT.format_map(KeepMissingDict(stage=stage))
-            paths = []
-            for _p in group_root_paths:
-                paths.extend(
-                    [
-                        (p_in, p_out)
-                        for p_in, p_out in zip(
-                            get_stage_paths(_p, template_in, defringe, ndither),
-                            get_stage_paths(_p, template_out, defringe, ndither),
-                        )
-                        if os.path.exists(p_in)
-                    ]
-                )
-
-            log(f'Processing {len(paths)} files...')
-            plot_args = [(p_in, p_out, plot_kwargs) for p_in, p_out in paths]
-            runmany(
-                plot_fn, plot_args, parallel_frac=parallel, desc=f'Plotting {stage}'
-            )
-
-        log('Plotting step complete\n')
-
-    if 'animate' not in skip_steps:
-        log('Generating animations...')
-        # Use dict for paths here as multiple input paths map to the same output
-        paths_dict: dict[str, list[str]] = {}
-        for stage in reversed(DATA_STAGES):
-            template_in = PATH_DATA.format_map(KeepMissingDict(stage=stage))
-            template_out = PATH_ANIMATION.format_map(KeepMissingDict(stage=stage))
-            for p_in, p_out in zip(
-                get_stage_paths(root_path, template_in, defringe, ndither),
-                get_stage_paths(root_path, template_out, defringe, ndither),
-            ):
-                if os.path.exists(p_in):
-                    paths_dict.setdefault(p_out, []).append(p_in)
-
-        log(f'{len(paths_dict)} animations to process...')
-        animation_kwargs = animation_kwargs or {}
-        animation_kwargs.setdefault('print_output', False)
-        if parallel:
-            animation_kwargs.setdefault('progress_bar', False)
-        animation_args = [
-            (p_out, p_ins, animation_kwargs) for p_out, p_ins in paths_dict.items()
-        ]
+# stage1
+def run_stage1(
+    group_root_paths: list[str],
+    stage1_kwargs: dict[str, Any] | None = None,
+    reduction_parallel_kwargs: dict[str, Any] | None = None,
+):
+    log('Running reduction stage 1')
+    kwargs = DEFAULT_STAGE1_KWARGS | (stage1_kwargs or {})
+    log(f'Arguments: {kwargs!r}', time=False)
+    for root_path in group_root_paths:
+        if len(group_root_paths) > 1:
+            log(f'Running reduction stage 1 for {root_path!r}')
+        paths_in = sorted(glob.glob(os.path.join(root_path, 'stage0', '*.fits')))
+        output_dir = os.path.join(root_path, 'stage1')
+        args_list = [(p, output_dir, kwargs) for p in paths_in]
+        log(f'Output directory: {output_dir!r}', time=False)
+        log(f'Processing {len(args_list)} files...', time=False)
+        check_path(output_dir)
         runmany(
-            animation_fn,
-            animation_args,
-            parallel_frac=parallel,
-            desc='Animating',
+            reduction_detector1_fn,
+            args_list,
+            desc='stage1',
+            **reduction_parallel_kwargs or {},
         )
-        log('Animation step complete\n')
+    log('Reduction stage 1 step complete\n')
 
-    log('MIRI pipeline complete')
-    log(f'Root path: {root_path!r}', time=False)
-    log(f'Defringe: {defringe!r}', time=False)
-    log(f'Desaturate: {desaturate!r}', time=False)
-    if skip_steps:
-        log(
-            f'Skipped steps: {", ".join([repr(s) for s in STEPS if s in skip_steps])}',
-            time=False,
+
+def reduction_detector1_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+    path_in, output_dir, kwargs = args
+
+    with fits.open(path_in) as hdul:
+        ngroups = hdul['PRIMARY'].header['NGROUPS']  # type: ignore
+    if ngroups <= 3:
+        kwargs['steps'] = kwargs.get('steps', {}) | {
+            'firstframe': {'skip': True},
+            'lastframe': {'skip': True},
+            'rscd': {'skip': True},
+            'jump': {'skip': True},
+        }
+
+    Detector1Pipeline.call(path_in, output_dir=output_dir, save_results=True, **kwargs)
+
+
+# stage2
+def run_stage2(
+    group_root_paths: list[str],
+    stage2_kwargs: dict[str, Any] | None = None,
+    reduction_parallel_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running reduction stage 2')
+    kwargs = DEFAULT_STAGE2_KWARGS | (stage2_kwargs or {})
+    log(f'Arguments: {kwargs!r}', time=False)
+    for root_path in group_root_paths:
+        if len(group_root_paths) > 1:
+            log(f'Running reduction stage 2 for {root_path!r}')
+        paths_in = sorted(glob.glob(os.path.join(root_path, 'stage1', '*rate.fits')))
+        output_dir = os.path.join(root_path, 'stage2')
+        args_list = [(p, output_dir, kwargs) for p in paths_in]
+        log(f'Output directory: {output_dir!r}', time=False)
+        log(f'Processing {len(args_list)} files...', time=False)
+        check_path(output_dir)
+        runmany(
+            reduction_spec2_fn,
+            args_list,
+            desc='stage2',
+            **reduction_parallel_kwargs or {},
         )
-    print()
+    log('Reduction stage 2 step complete\n')
 
 
-def despike_fn(args: tuple[str, str, dict[str, Any] | None]):
-    p_in, p_out, despike_kwargs = args
-    despike_data.despike_cube(p_in, p_out, **despike_kwargs or {})
+def reduction_spec2_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+    path_in, output_dir, kwargs = args
+    Spec2Pipeline.call(path_in, output_dir=output_dir, save_results=True, **kwargs)
 
 
-def plot_fn(args: tuple[str, str, dict[str, Any] | None]):
-    p_in, p_out, plot_kwargs = args
-    jwst_summary_plots.make_summary_plot(p_in, p_out, **plot_kwargs or {})
+# defringe
+def run_defringe(
+    group_root_paths: list[str],
+    defringe_kwargs: dict[str, Any] | None = None,
+    reduction_parallel_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running reduction defringe')
+    kwargs = DEFAULT_DEFRINGE_KWARGS | (defringe_kwargs or {})
+    log(f'Arguments: {kwargs!r}', time=False)
+    for root_path in group_root_paths:
+        if len(group_root_paths) > 1:
+            log(f'Running defringe for {root_path!r}')
+        paths_in = sorted(glob.glob(os.path.join(root_path, 'stage2', '*cal.fits')))
+        output_dir = os.path.join(root_path, 'stage2')
+        args_list = [(p, output_dir, kwargs) for p in paths_in]
+        log(f'Output directory: {output_dir!r}', time=False)
+        log(f'Processing {len(args_list)} files...', time=False)
+        check_path(output_dir)
+        runmany(
+            defringe_fn,
+            args_list,
+            desc='defringe',
+            **reduction_parallel_kwargs or {},
+        )
+    log('Defringe step complete\n')
 
 
-def animation_fn(args: tuple[str, list[str], dict[str, Any] | None]):
-    p_out, p_ins, animation_kwargs = args
-    jwst_summary_animation.make_animation(p_ins, p_out, **animation_kwargs or {})
+def defringe_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+    path_in, output_dir, kwargs = args
+    ResidualFringeStep.call(path_in, output_dir=output_dir, save_results=True, **kwargs)
 
 
-def get_stage_paths(
-    root_path: str | None,
-    template: str,
+# stage3
+def run_stage3(
+    group_root_paths: list[str],
+    defringe_options: list[bool],
+    stage3_kwargs: dict[str, Any] | None = None,
+    reduction_parallel_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running reduction stage 3')
+    kwargs = DEFAULT_STAGE3_KWARGS | (stage3_kwargs or {})
+    log(f'Arguments: {kwargs!r}', time=False)
+
+    # TODO only include tile in prodname if needed
+    for defringe in defringe_options:
+        for root_path in group_root_paths:
+            log(f'Running reduction stage 3 for defringe={defringe}, {root_path!r}')
+            grouped_files = group_stage2_files_for_stage3(root_path, defringe)
+            asn_paths_list: list[tuple[str, str]] = []
+            for (dither, channel, band), paths in grouped_files.items():
+                dirname = 'combined' if dither is None else f'd{dither}'
+                if defringe:
+                    dirname += '_fringe'
+                output_dir = os.path.join(root_path, 'stage3', dirname)
+                check_path(output_dir)
+                asn_path = os.path.join(
+                    output_dir, f'l3asn-{channel}_{band}_dither-{dither}.json'
+                )
+                write_asn_for_stage3(paths, asn_path, prodname=f'Level3')
+                asn_paths_list.append((asn_path, output_dir))
+            args_list = [
+                (p, output_dir, kwargs) for p, output_dir in sorted(asn_paths_list)
+            ]
+            log(f'Processing {len(args_list)} files...', time=False)
+            runmany(
+                reduction_spec3_fn,
+                args_list,
+                desc='stage3',
+                **reduction_parallel_kwargs or {},
+            )
+    log('Reduction stage 3 step complete\n')
+
+
+def group_stage2_files_for_stage3(
+    root_path: str,
     defringe: bool,
-    ndither: int,
-) -> list[str]:
+) -> dict[tuple[int | None, str, str], list[str]]:
+    out: dict[tuple[int | None, str, str], list[str]] = {}
+    suffix = 'residual_fringe.fits' if defringe else 'cal.fits'
+    paths_in = sorted(glob.glob(os.path.join(root_path, 'stage2', f'*{suffix}')))
+    for p in paths_in:
+        with fits.open(p) as hdul:
+            hdr = hdul[0].header  #  type: ignore
+        dither = int(hdr['PATT_NUM'])
+        channel = hdr['CHANNEL']
+        band = hdr['BAND']
+
+        # Keep dithers separate
+        k = (dither, channel, band)
+        out.setdefault(k, []).append(p)
+
+        # Combine dithers
+        k = (None, channel, band)
+        out.setdefault(k, []).append(p)
+    return out
+
+
+def write_asn_for_stage3(
+    files: list[str], asnfile: str, prodname: str, **kwargs
+) -> None:
+    asn = asn_from_list(files, rule=DMS_Level3_Base, product_name=prodname)
+    if 'bg' in kwargs:
+        for bgfile in kwargs['bg']:
+            asn['products'][0]['members'].append(
+                {'expname': bgfile, 'exptype': 'background'}
+            )
+    _, serialized = asn.dump()
+    with open(asnfile, 'w', encoding='utf-8') as outfile:
+        outfile.write(serialized)
+
+
+def reduction_spec3_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+    asn_path, output_dir, kwargs = args
+    Spec3Pipeline.call(
+        asn_path,
+        output_dir=output_dir,
+        save_results=True,
+        **kwargs,
+    )
+
+
+# navigation
+def run_navigate(
+    group_root_paths: list[str],
+    defringe_options: list[bool],
+    basic_navigation: bool = False,
+    navigate_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running navigate')
+    kwargs = DEFAULT_NAVIGATE_KWARGS | (navigate_kwargs or {})
+    log(f'Basic navigation: {basic_navigation!r}', time=False)
+    log(f'Arguments: {kwargs!r}', time=False)
+    navigate_jwst_observations.load_kernels()
+    for defringe in defringe_options:
+        for root_path in group_root_paths:
+            log(f'Running navigation for defringe={defringe}, {root_path!r}')
+            paths_in = sorted(
+                filter_paths_by_defringe(
+                    glob.glob(os.path.join(root_path, 'stage3', '*', '*_s3d.fits')),
+                    defringe,
+                )
+            )
+            navigate_jwst_observations.navigate_multiple(
+                *paths_in, basic=basic_navigation, **kwargs
+            )
+    log('Navigate step complete\n')
+
+
+# desaturate
+def run_desaturate(
+    root_path: str,
+    group_root_paths: list[str],
+    defringe_options: list[bool],
+    desaturate_kwargs: dict[str, Any] | None = None,
+    parallel_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running desaturate')
+    kwargs = DEFAULT_DESATURATE_KWARGS | (desaturate_kwargs or {})
+    parallel_kwargs = parallel_kwargs or {}
+    log(f'Arguments: {kwargs!r}', time=False)
+
+    for defringe in defringe_options:
+        log(f'Running desaturation for defringe={defringe!r}')
+        paths_dict: dict[str, list[str]] = {}
+        for rp in group_root_paths:
+            paths_in = sorted(
+                filter_paths_by_defringe(
+                    glob.glob(os.path.join(rp, 'stage3', '*_nav', '*_nav.fits')),
+                    defringe,
+                )
+            )
+            for p_in in paths_in:
+                relpath = os.path.relpath(p_in, rp)
+                relpath = replace_path_part(
+                    relpath, -3, 'stage3_desaturated', check_old='stage3'
+                )
+                p_out = os.path.join(root_path, relpath)
+                paths_dict.setdefault(p_out, []).append(p_in)
+        args_list = [
+            (paths_in, p_out, kwargs) for p_out, paths_in in paths_dict.items()
+        ]
+        log(f'Processing {len(args_list)} output files...', time=False)
+        runmany(desaturate_fn, args_list, desc='desaturate', **parallel_kwargs)
+    log('Desaturate step complete\n')
+
+
+def desaturate_fn(args: tuple[list[str], str, dict[str, Any]]) -> None:
+    paths_in, path_out, kwargs = args
+    desaturate_data.replace_saturated(paths_in, path_out, **kwargs)
+
+
+# flat
+def run_flat(
+    root_path: str,
+    defringe_options: list[bool],
+    flat_data_path: str,
+    flat_kwargs: dict[str, Any] | None = None,
+    input_stage: str = 'stage3',
+) -> None:
+    log('Running flat')
+    kwargs = DEFAULT_FLAT_KWARGS | (flat_kwargs or {})
+    log(f'Arguments: {kwargs!r}', time=False)
+    log(f'Flat data path: {flat_data_path!r}', time=False)
+
+    for defringe in defringe_options:
+        log(f'Running flat for defringe={defringe!r}')
+        paths_in = sorted(
+            filter_paths_by_defringe(
+                glob.glob(os.path.join(root_path, input_stage, '*_nav.fits')),
+                defringe,
+            )
+        )
+        log(f'Processing {len(paths_in)} input files...', time=False)
+        for p_in in tqdm.tqdm(paths_in, desc='flat'):
+            p_out = replace_path_part(p_in, -3, 'stage4_flat', check_old=input_stage)
+            with fits.open(p_in) as hdul:
+                hdr = hdul['PRIMARY'].header  #  type: ignore
+            p_flat = flat_data_path.format(
+                channel=hdr['CHANNEL'],
+                band=hdr['BAND'],
+                fringe='_fringe' if defringe else '',
+            )
+            flat_field.apply_flat(p_in, p_out, p_flat, **kwargs)
+    log('Flat step complete\n')
+
+
+# despike
+def run_despike(
+    root_path: str,
+    defringe_options: list[bool],
+    despike_kwargs: dict[str, Any] | None = None,
+    parallel_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running despike')
+    parallel_kwargs = parallel_kwargs or {}
+    kwargs = DEFAULT_DESPIKE_KWARGS | (despike_kwargs or {})
+    if parallel_kwargs.get('parallel_frac', False):
+        kwargs.setdefault('progress_bar', False)
+    log(f'Arguments: {kwargs!r}', time=False)
+
+    for defringe in defringe_options:
+        log(f'Running despike for defringe={defringe!r}')
+        paths_in = sorted(
+            filter_paths_by_defringe(
+                glob.glob(
+                    os.path.join(root_path, 'stage4_flat', '*_nav', '*_nav.fits')
+                ),
+                defringe,
+            )
+        )
+        paths_out = [
+            replace_path_part(p, -3, 'stage5_despike', check_old='stage4_flat')
+            for p in paths_in
+        ]
+        args_list = [(p_in, p_out, kwargs) for p_in, p_out in zip(paths_in, paths_out)]
+        log(f'Processing {len(args_list)} files...', time=False)
+        runmany(despike_fn, args_list, desc='despike', **parallel_kwargs)
+    log('Despike step complete\n')
+
+
+def despike_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+    p_in, p_out, kwargs = args
+    despike_data.despike_cube(p_in, p_out, **kwargs)
+
+
+# background
+def run_background(
+    root_path: str,
+    defringe_options: list[bool],
+    background_path: str,
+    background_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running background')
+    kwargs = DEFAULT_BACKGROUND_KWARGS | (background_kwargs or {})
+    log(f'Arguments: {kwargs!r}', time=False)
+
+    for defringe in defringe_options:
+        log(f'Runnning background subtraction for defringe={defringe!r}')
+        paths_in = sorted(
+            filter_paths_by_defringe(
+                glob.glob(
+                    os.path.join(root_path, 'stage5_despike', '*_nav', '*_nav.fits')
+                ),
+                defringe,
+            )
+        )
+        log(f'Processing {len(paths_in)} input files...', time=False)
+        for p_in in tqdm.tqdm(paths_in, desc='background'):
+            p_out = replace_path_part(
+                p_in, -3, 'stage6_background', check_old='stage5_despike'
+            )
+            with fits.open(p_in) as hdul:
+                hdr = hdul['PRIMARY'].header  #  type: ignore
+            p_background = os.path.join(
+                background_path,
+                'stage5_despike',
+                'd{dither}{fringe}_nav',
+                'Level3_ch{channel}-{band}_s3d_nav.fits',
+            ).format(
+                channel=hdr['CHANNEL'],
+                band=hdr['BAND'],
+                fringe='_fringe' if defringe else '',
+                dither='1',
+            )
+            background_subtraction.subtract_background(
+                p_in, p_out, p_background, **kwargs
+            )
+    log('Background step complete\n')
+
+
+# plot
+def run_plot(
+    group_root_paths: list[str],
+    defringe_options: list[bool],
+    plot_kwargs: dict[str, Any] | None = None,
+    parallel_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running plot')
+    kwargs = DEFAULT_PLOT_KWARGS | (plot_kwargs or {})
+    parallel_kwargs = parallel_kwargs or {}
+    log(f'Arguments: {kwargs!r}', time=False)
+
+    for defringe in defringe_options:
+        for root_path in group_root_paths:
+            log(f'Generating quick look plots for defringe={defringe}, {root_path!r}')
+            for stage in reversed(DATA_STAGES):
+                log(f'Generating quick look plots for stage {stage!r}')
+                paths_in = sorted(
+                    filter_paths_by_defringe(
+                        glob.glob(
+                            os.path.join(root_path, stage, '*_nav', '*_nav.fits')
+                        ),
+                        defringe,
+                    )
+                )
+                paths_out = []
+                for p_in in paths_in:
+                    dir_out = os.path.dirname(
+                        replace_path_part(
+                            p_in, -3, os.path.join('plots', stage), check_old=stage
+                        )
+                    )
+                    filename_out = '{prefix}_{filename}'.format(
+                        prefix=get_channel_band_prefix(p_in),
+                        filename=os.path.basename(
+                            replace_path_suffix(p_in, '.png', check_old='.fits')
+                        ),
+                    )
+                    p_out = os.path.join(dir_out, filename_out)
+                    paths_out.append(p_out)
+
+                args_list = [
+                    (p_in, p_out, kwargs) for p_in, p_out in zip(paths_in, paths_out)
+                ]
+                log(f'Processing {len(args_list)} files...', time=False)
+                runmany(plot_fn, args_list, desc='plot', **parallel_kwargs)
+    log('Plot step complete\n')
+
+
+def plot_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+    p_in, p_out, kwargs = args
+    jwst_summary_plots.make_summary_plot(p_in, p_out, **kwargs)
+
+
+# animate
+def run_animate(
+    root_path: str,
+    defringe_options: list[bool],
+    animate_kwargs: dict[str, Any] | None = None,
+    parallel_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running animate')
+    kwargs = DEFAULT_ANIMATE_KWARGS | (animate_kwargs or {})
+    parallel_kwargs = parallel_kwargs or {}
+    if parallel_kwargs.get('parallel_frac', False):
+        kwargs.setdefault('progress_bar', False)
+    log(f'Arguments: {kwargs!r}', time=False)
+    for defringe in defringe_options:
+        for stage in reversed(DATA_STAGES):
+            log(
+                f'Generating quick look animations for stage {stage!r}, defringe={defringe!r}'
+            )
+            paths_in = sorted(
+                filter_paths_by_defringe(
+                    glob.glob(os.path.join(root_path, stage, 'd*_nav', '*_nav.fits')),
+                    defringe,
+                )
+            )
+            paths_dict: dict[str, list[str]] = {}
+            for p_in in paths_in:
+                filename = f'{get_channel_band_prefix(p_in)}_animation.mp4'
+                fringe_directory = 'dither_comparison' + ('_fringe' if defringe else '')
+                p_out = os.path.join(
+                    root_path, 'animation', stage, fringe_directory, filename
+                )
+                paths_dict.setdefault(p_out, []).append(p_in)
+            args_list = [
+                (paths_in, p_out, kwargs) for p_out, paths_in in paths_dict.items()
+            ]
+            log(f'Processing {len(args_list)} files...', time=False)
+            runmany(animation_fn, args_list, desc='animate', **parallel_kwargs)
+    log('Animate step complete\n')
+
+
+def animation_fn(args: tuple[list[str], str, dict[str, Any]]) -> None:
+    paths_in, p_out, kwargs = args
+    jwst_summary_animation.make_animation(paths_in, p_out, **kwargs)
+
+
+# utils
+def filter_paths_by_defringe(paths: list[str], defringe: bool) -> list[str]:
+    # Return paths matching .../*_fringe*/* if defringe=True
+    return [p for p in paths if ('_fringe' in pathlib.Path(p).parts[-2]) == defringe]
+
+
+def replace_path_part(
+    path: str, idx: int, new: str, *, check_old: str | None = None
+) -> str:
     """
-    Get a list of paths for all combinations of dithers, channels and bands for a given
-    stage of the reduction.
+    Replace a part of a path with a new value.
 
     Args:
-        root_path: Directory containing the data.
-        template: Path of the data files relative to the `root_path`. The values
-            `{dither}`, `{channel}`, `{band}`, `{abc}` and `{fringe}` will be replaced
-            with the corresponding values for each individual file.
-        defringe: Toggle defringing.
-        ndither: Number of dithers.
+        path: The path to modify.
+        idx: The index of the part to replace in the directory tree.
+        new: The new value to use.
+        check_old: If not None, check that the value at the index is this value
+            before replacing it.
 
     Returns:
-        List of file paths, constructed from the root path and the template.
+        The modified path.
     """
-    if root_path:
-        template = os.path.join(root_path, template)
-    fringe = '_fringe' if defringe else ''
-    dithers = [str(i + 1) for i in range(ndither)]
+    p = pathlib.Path(path)
+    parts = list(p.parts)
+    if check_old is not None and parts[idx] != check_old:
+        raise ValueError(f'Expected {check_old!r} at index {idx} in {path!r}')
+    parts[idx] = new
+    return str(pathlib.Path(*parts))
 
-    paths = []
-    for path_kw in all_combinations(
-        dither=dithers,
-        channel=CHANNELS,
-        band=BANDS,
-    ):
-        path_kw['abc'] = CHANNEL_LENGTH_ALIASES[path_kw['band']]
-        paths.append(template.format(fringe=fringe, **path_kw))
-    return paths
+
+def replace_path_suffix(path: str, new: str, *, check_old: str | None = None) -> str:
+    """
+    Replace the suffix of a path with a new value.
+
+    Args:
+        path: The path to modify.
+        new: The new value to use.
+        check_old: If not None, check that the suffix is this value before
+            replacing it.
+
+    Returns:
+        The modified path.
+    """
+    p = pathlib.Path(path)
+    if check_old is not None and p.suffix != check_old:
+        raise ValueError(f'Expected {check_old!r} suffix in {path!r}')
+    return str(p.with_suffix(new))
+
+
+def get_channel_band_prefix(path: str) -> str:
+    """
+    Get channel-band prefix for a MIRI cube (e.g. '1B', '4C' etc.)
+    """
+    with fits.open(path) as hdul:
+        hdr = hdul['PRIMARY'].header  #  type: ignore
+    channel = hdr['CHANNEL']
+    abc = MIRI_BAND_ABC_ALIASES[hdr['BAND'].casefold().strip()]
+    return f'{channel}{abc}'
 
 
 def main():
@@ -782,17 +1158,11 @@ def main():
         '--background_path',
         type=str,
         help="""Path to directory containing background data. For example, if
-            your `root_path` is `/data/saturn/SATURN-15N`, the `background_path` may
-            be `/data/saturn/SATURN-BACKGROUND`. Note that background subtraction will
+            your `root_path` is `/data/uranus/lon1`, the `background_path` may
+            be `/data/uranus/background`. Note that background subtraction will
             require the background data to be already reduced. If no `background_path`
             is specified (the default), then no background subtraction will be 
             performed.""",
-    )
-    parser.add_argument(
-        '--ndither',
-        type=int,
-        default=4,
-        help="""Number of dithers in the dataset. Defaults to 4.""",
     )
     parser.add_argument(
         '--parallel',
@@ -847,8 +1217,8 @@ def main():
         type=str,
         help="""JSON string containing keyword arguments to pass to individual pipeline
             steps. For example, 
-            `--kwargs '{"reduction": {"stages": [2, 3]}, "animation": {"radius_factor": 2.5}}'` 
-            will pass the custom arguments to the reduction and animation steps.
+            `--kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "animation": {"radius_factor": 2.5}}'` 
+            will pass the custom arguments to the stage3 and animation steps.
             """,
     )
     args = vars(parser.parse_args())

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -266,7 +266,7 @@ DEFAULT_STAGE1_KWARGS = {}
 DEFAULT_STAGE2_KWARGS = {
     'steps': {'cube_build': {'skip': True}, 'extract_1d': {'skip': True}}
 }
-DEFAULT_DEFRINGE_KWARGS = {}
+DEFAULT_DEFRINGE_KWARGS = {'skip': False}
 DEFAULT_STAGE3_KWARGS = {
     'steps': {
         'master_background': {'skip': True},

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -61,6 +61,15 @@ defringe step disabled, then with it enabled. If you only want defringed or
 non-defringed data, you can customise this behaviour with the `defringe` argument or the
 `--defringe` or `--no-defringe` flags.
 
+If the pipeline is run with desaturation enabled, the pipeline flow is:
+- Firstly, multiple versions of the stage0 cubes are greated with different numbers of 
+  groups (the `remove_groups` step).
+- The `reduction` and `navigation` steps are run on e.g. the 4 group data, then the
+  3 group data, then the 2 group data, then the 1 group data.
+- The `desaturate` step is then run to combine the various group data into a single
+  desaturated dataset.
+- Subsequent pipeline steps (e.g. `plot`) are run on the desaturated data.
+
 For more command line examples, see CLI_EXAMPLES below, and for more Python examples,
 see the docstring for `run_pipeline()` below.
 
@@ -152,6 +161,9 @@ python3 miri_pipeline.py /data/saturn/SATURN-15N --background_path /data/saturn/
 
 # Run the pipeline, but stop before creating any visualisations
 python3 miri_pipeline.py /data/saturn/SATURN-15N --end_step despike
+
+# Only run the plotting step
+python3 miri_pipeline.py /data/saturn/SATURN-15N --start_step plot --end_step plot
 
 # Re-run the pipeline, skipping the initial reduction steps
 python3 miri_pipeline.py /data/saturn/SATURN-15N --start_step desaturate

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -59,12 +59,12 @@ This will run the full pipeline, and output data files appropriate directories (
 `/data/uranus/lon1/stage3`, `/data/uranus/lon1/plots` etc.).
 
 By default, most steps of the pipeline are effectively run twice, each step with the 
-redisdual defringe step disabled first, then with it enabled. If you only want defringed
+residual defringe step disabled first, then with it enabled. If you only want defringed
 or non-defringed data, you can customise this behaviour with the `defringe` argument or 
 the `--defringe` or `--no-defringe` flags.
 
 If the pipeline is run with desaturation enabled, the pipeline flow is:
-- Firstly, multiple versions of the stage0 cubes are greated with different numbers of 
+- Firstly, multiple versions of the stage0 cubes are created with different numbers of 
   groups (the `remove_groups` step).
 - `stage1` is run on e.g. the 4 group data, then the 3 group data, then the 2 group
   data, then the 1 group data. Then `stage2` is run on the 4-1 group data, then 
@@ -138,7 +138,7 @@ STEP_DESCRIPTIONS = """
 - `remove_groups`: Remove groups from the data (for use in desaturating the data) [optional].
 - `stage1`: Run the standard JWST reduction pipeline stage 1.
 - `stage2`: Run the standard JWST reduction pipeline stage 2.
-- `defringe`: Run thhe JWST reduction pipeline residual fringe step [optional].
+- `defringe`: Run the JWST reduction pipeline residual fringe step [optional].
 - `stage3`: Run the standard JWST reduction pipeline stage 3.
 - `navigate`: Navigate reduced files.
 - `desaturate`: Desaturate data using cubes with fewer groups [optional].
@@ -683,7 +683,6 @@ def run_stage3(
     kwargs = DEFAULT_STAGE3_KWARGS | (stage3_kwargs or {})
     log(f'Arguments: {kwargs!r}', time=False)
 
-    # TODO only include tile in prodname if needed
     for defringe in defringe_options:
         for root_path in group_root_paths:
             log(f'Running reduction stage 3 for defringe={defringe}, {root_path!r}')
@@ -933,7 +932,7 @@ def run_background(
     log(f'Arguments: {kwargs!r}', time=False)
 
     for defringe in defringe_options:
-        log(f'Runnning background subtraction for defringe={defringe!r}')
+        log(f'Running background subtraction for defringe={defringe!r}')
         paths_in = sorted(
             filter_paths_by_defringe(
                 glob.glob(

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -866,7 +866,7 @@ def run_flat(
         log(f'Running flat for defringe={defringe!r}')
         paths_in = sorted(
             filter_paths_by_defringe(
-                glob.glob(os.path.join(root_path, input_stage, '*_nav', '*_nav.fits')),
+                glob.glob(os.path.join(root_path, input_stage, 'd*_nav', '*_nav.fits')),
                 defringe,
             )
         )
@@ -877,7 +877,7 @@ def run_flat(
                 hdr = hdul['PRIMARY'].header  #  type: ignore
             p_flat = flat_data_path.format(
                 channel=hdr['CHANNEL'],
-                band=hdr['BAND'],
+                band=hdr['BAND'].lower(),
                 fringe='_fringe' if defringe else '',
             )
             flat_field.apply_flat(p_in, p_out, p_flat, **kwargs)
@@ -957,7 +957,7 @@ def run_background(
                 'd{dither}{fringe}_nav',
                 'Level3_ch{channel}-{band}_s3d_nav.fits',
             ).format(
-                channel=hdr['CHANNEL'].lower(),
+                channel=hdr['CHANNEL'],
                 band=hdr['BAND'].lower(),
                 fringe='_fringe' if defringe else '',
                 dither='1',

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -177,7 +177,8 @@ python3 miri_pipeline.py /data/uranus/lon1 --start_step desaturate
 # Run the pipeline, passing custom arguments to different steps
 python3 miri_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "plot": {"plot_brightest_spectrum": true}, "animation": {"radius_factor": 2.5}}'
 """
-
+# TODO shift bg subtraction to stage2 and create versions with and withouth bg
+# subtraction (like defringe)?
 import argparse
 import glob
 import json

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -686,7 +686,7 @@ def run_stage3(
 
     for defringe in defringe_options:
         for root_path in group_root_paths:
-            log(f'Running reduction stage 3 for defringe={defringe}, {root_path!r}')
+            log(f'Running reduction stage 3 for defringe={defringe} on {root_path!r}')
             grouped_files = group_stage2_files_for_stage3(root_path, defringe)
 
             # Only need to include the tile in prodname if it is needed to avoid filename
@@ -712,7 +712,8 @@ def run_stage3(
                 write_asn_for_stage3(
                     paths,
                     asn_path,
-                    prodname='Level3' + f'_{tile}' if include_tile_in_prodname else '',
+                    prodname='Level3'
+                    + (f'_{tile}' if include_tile_in_prodname else ''),
                 )
                 asn_paths_list.append((asn_path, output_dir))
             args_list = [
@@ -791,7 +792,7 @@ def run_navigate(
     navigate_jwst_observations.load_kernels()
     for defringe in defringe_options:
         for root_path in group_root_paths:
-            log(f'Running navigation for defringe={defringe}, {root_path!r}')
+            log(f'Running navigation for defringe={defringe} on {root_path!r}')
             paths_in = sorted(
                 filter_paths_by_defringe(
                     glob.glob(os.path.join(root_path, 'stage3', '*', '*_s3d.fits')),
@@ -864,7 +865,7 @@ def run_flat(
         log(f'Running flat for defringe={defringe!r}')
         paths_in = sorted(
             filter_paths_by_defringe(
-                glob.glob(os.path.join(root_path, input_stage, '*_nav.fits')),
+                glob.glob(os.path.join(root_path, input_stage, '*_nav', '*_nav.fits')),
                 defringe,
             )
         )
@@ -980,7 +981,7 @@ def run_plot(
 
     for defringe in defringe_options:
         for root_path in group_root_paths:
-            log(f'Generating quick look plots for defringe={defringe}, {root_path!r}')
+            log(f'Generating quick look plots for defringe={defringe} on {root_path!r}')
             for stage in reversed(DATA_STAGES):
                 log(f'Generating quick look plots for stage {stage!r}')
                 paths_in = sorted(

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -174,7 +174,7 @@ python3 miri_pipeline.py /data/uranus/lon1 --start_step plot --end_step plot
 python3 miri_pipeline.py /data/uranus/lon1 --start_step desaturate
 
 # Run the pipeline, passing custom arguments to different steps
-python3 miri_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "plot": {"plot_brightest_spectrum": false}, "animation": {"radius_factor": 2.5}}'
+python3 miri_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "plot": {"plot_brightest_spectrum": true}}'
 """
 import argparse
 import os
@@ -305,7 +305,7 @@ def run_pipeline(
                 'stage3: {
                     'outlier_detection': {'snr': '30.0 24.0', 'scale': '1.3 0.7'}
                 },
-                'plot': {'plot_brightest_spectrum': False},
+                'plot': {'plot_brightest_spectrum': True},
                 'animate': {'radius_factor': 2.5},
             },
         )
@@ -359,7 +359,7 @@ def run_pipeline(
         reduction_parallel_kwargs: Dictionary of keyword arguments to customise parallel
             processing for the reduction steps (i.e. `stage1`-`stage3`). This will be
             merged with `parallel_kwargs` (i.e.
-            `parallel_kwargs | reduction_parallel_kwargs
+            `parallel_kwargs | reduction_parallel_kwargs`).
 
         defringe: Toggle defringing of the data. If True, defringe data will be saved
             and processed. If `'both'` (the default), the pipeline steps will
@@ -434,13 +434,13 @@ class MiriPipeline(Pipeline):
     def stage_directories_to_plot(self) -> tuple[str, ...]:
         return STAGE_DIRECTORIES_TO_PLOT
 
-    def process_skip_steps(
+    def process_steps_list(
         self,
         skip_steps: Collection[Step] | None,
         start_step: Step | None,
         end_step: Step | None,
     ) -> set[Step]:
-        skip_steps = super().process_skip_steps(skip_steps, start_step, end_step)
+        skip_steps = super().process_steps_list(skip_steps, start_step, end_step)
         if not self.defringe:
             skip_steps.add('defringe')
         return skip_steps

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -110,7 +110,7 @@ To use this script you will need to:
 
     #!/bin/bash
     #
-    #PBS -N MIRI_Pipeline
+    #PBS -N Pipeline
     #PBS -l walltime=24:00:00
     #PBS -l vmem=80gb
     #PBS -l nodes=1:ppn=8
@@ -137,14 +137,13 @@ To use this script you will need to:
 STEP_DESCRIPTIONS = """
 - `remove_groups`: Remove groups from the data (for use in desaturating the data) [optional].
 - `stage1`: Run the standard JWST reduction pipeline stage 1.
-- `stage2`: Run the standard JWST reduction pipeline stage 2.
+- `stage2`: Run the standard JWST reduction pipeline stage 2 (including optional background subtraction).
 - `defringe`: Run the JWST reduction pipeline residual fringe step [optional].
 - `stage3`: Run the standard JWST reduction pipeline stage 3.
 - `navigate`: Navigate reduced files.
 - `desaturate`: Desaturate data using cubes with fewer groups [optional].
 - `flat`: Correct flat effects using synthetic flat field cubes.
 - `despike`: Clean cubes by removing extreme outlier pixels.
-- `background`: Subtract background from cubes [optional].
 - `plot`: Generate quick look summary plots of data.
 - `animate`: Generate summary animations of data.
 """
@@ -175,37 +174,22 @@ python3 miri_pipeline.py /data/uranus/lon1 --start_step plot --end_step plot
 python3 miri_pipeline.py /data/uranus/lon1 --start_step desaturate
 
 # Run the pipeline, passing custom arguments to different steps
-python3 miri_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "plot": {"plot_brightest_spectrum": true}, "animation": {"radius_factor": 2.5}}'
+python3 miri_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "plot": {"plot_brightest_spectrum": false}, "animation": {"radius_factor": 2.5}}'
 """
-# TODO shift bg subtraction to stage2 and create versions with and withouth bg
-# subtraction (like defringe)?
 import argparse
-import glob
-import json
 import os
-import pathlib
-from typing import Any, Literal, TypeAlias
+from typing import Any, Collection, Literal
 
 import tqdm
 from astropy.io import fits
-from jwst.associations.asn_from_list import asn_from_list
-from jwst.associations.lib.rules_level3_base import DMS_Level3_Base
-from jwst.pipeline import Detector1Pipeline, Spec2Pipeline, Spec3Pipeline
 from jwst.residual_fringe import ResidualFringeStep
 
-import background_subtraction
-import desaturate_data
-import despike_data
 import flat_field
-import jwst_summary_animation
-import jwst_summary_plots
-import navigate_jwst_observations
-import remove_groups
 from parallel_tools import runmany
-from tools import check_path, log
+from pipeline import Pipeline, Step, get_pipeline_argument_parser
 
-# Pipeline constants
-Step: TypeAlias = Literal[
+# Pipeline constants for MIRI
+STEPS = (
     'remove_groups',
     'stage1',
     'stage2',
@@ -215,104 +199,77 @@ Step: TypeAlias = Literal[
     'desaturate',
     'flat',
     'despike',
-    'background',
     'plot',
     'animate',
-]
-STEPS: list[Step] = [
-    'remove_groups',
-    'stage1',
-    'stage2',
-    'defringe',
-    'stage3',
-    'navigate',
-    'desaturate',
-    'flat',
-    'despike',
-    'background',
-    'plot',
-    'animate',
-]
-
-DATA_STAGES = [
+)
+DEFAULT_KWARGS: dict[Step, dict[str, Any]] = {
+    'stage2': {
+        'steps': {
+            'cube_build': {'skip': True},
+            'extract_1d': {'skip': True},
+            'bkg_subtract': {'skip': False},
+        },
+    },
+    'stage3': {
+        'steps': {
+            'extract_1d': {'skip': True},
+            'cube_build': {'output_type': 'band', 'coord_system': 'ifualign'},
+        }
+    },
+}
+STAGE_DIRECTORIES_TO_PLOT = (
     'stage3',
     'stage3_desaturated',
     'stage4_flat',
     'stage5_despike',
     'stage6_background',
-]
-
-# Get a useful default flat data path that works natively on Leicester's ALICE HPC
-_saturn_flat_path = os.path.join(
-    'MIRI_IFU/Saturn_2022nov13/flat_field/merged',
-    'ch{channel}-{band}_constructed_flat{fringe}.fits',
 )
-_path_options = [
-    os.path.join('/data/nemesis/jwst', _saturn_flat_path),
-    os.path.join(os.path.dirname(__file__), '..', 'jwst_data', _saturn_flat_path),
+STEP_DIRECTORIES: dict[Step, tuple[str, str]] = {
+    'defringe': ('stage2', 'stage2'),
+    'flat': ('', 'stage4_flat'),
+    'despike': ('stage4_flat', 'stage5_despike'),
+}
+
+BAND_ABC_ALIASES = {'short': 'A', 'medium': 'B', 'long': 'C'}
+
+
+# Try to get a useful default flat data path that at least works natively on Leicester's
+# ALICE HPC
+_path_options = (
+    '/data/nemesis/jwst/MIRI_IFU/flat_field',
+    os.path.join(
+        os.path.dirname(__file__), '..', 'jwst_data', 'MIRI_IFU', 'flat_field'
+    ),
+    os.path.join(os.path.dirname(__file__), '..', 'jwst_data', 'flat_field'),
     os.path.join(os.path.dirname(__file__), 'flat_field'),
-]
+)
 DEFAULT_FLAT_DATA_PATH = _path_options[-1]
 for _p in _path_options:
     if os.path.exists(os.path.dirname(_p)):
         DEFAULT_FLAT_DATA_PATH = os.path.normpath(_p)
         break
 
-MIRI_BAND_ABC_ALIASES = {'short': 'A', 'medium': 'B', 'long': 'C'}
-
-# Default arguments for each step. These are merged with the user-supplied kwargs
-# before being passed to the pipeline, for example:
-# stage1_kwargs = DEFAULT_STAGE1_KWARGS | stage1_kwargs
-DEFAULT_STAGE1_KWARGS = {}
-DEFAULT_STAGE2_KWARGS = {
-    'steps': {'cube_build': {'skip': True}, 'extract_1d': {'skip': True}}
-}
-DEFAULT_DEFRINGE_KWARGS = {'skip': False}
-DEFAULT_STAGE3_KWARGS = {
-    'steps': {
-        'master_background': {'skip': True},
-        'extract_1d': {'skip': True},
-        'cube_build': {'output_type': 'band', 'coord_system': 'ifualign'},
-    }
-}
-DEFAULT_DESATURATE_KWARGS = {}
-DEFAULT_NAVIGATE_KWARGS = {}
-DEFAULT_FLAT_KWARGS = {}
-DEFAULT_DESPIKE_KWARGS = {}
-DEFAULT_BACKGROUND_KWARGS = {}
-DEFAULT_PLOT_KWARGS = {}
-DEFAULT_ANIMATE_KWARGS = {}
-
 
 def run_pipeline(
     root_path: str,
     *,
-    defringe: bool | Literal['both'] = 'both',
-    desaturate: bool = True,
-    groups_to_use: list[int] | None = None,
-    background_path: str | None = None,
-    parallel: float | bool = False,
-    flat_data_path: str = DEFAULT_FLAT_DATA_PATH,
-    basic_navigation: bool = False,
-    skip_steps: list[Step] | set[Step] | None = None,
+    skip_steps: Collection[Step] | None = None,
     start_step: Step | None = None,
     end_step: Step | None = None,
-    stage1_kwargs: dict[str, Any] | None = None,
-    stage2_kwargs: dict[str, Any] | None = None,
-    defringe_kwargs: dict[str, Any] | None = None,
-    stage3_kwargs: dict[str, Any] | None = None,
-    navigate_kwargs: dict[str, Any] | None = None,
-    desaturate_kwargs: dict[str, Any] | None = None,
-    flat_kwargs: dict[str, Any] | None = None,
-    despike_kwargs: dict[str, Any] | None = None,
-    background_kwargs: dict[str, Any] | None = None,
-    plot_kwargs: dict[str, Any] | None = None,
-    animate_kwargs: dict[str, Any] | None = None,
+    parallel: float | bool = False,
+    desaturate: bool = True,
+    groups_to_use: list[int] | None = None,
+    background_subtract: bool | Literal['both'] = 'both',
+    background_path: str | None = None,
+    basic_navigation: bool = False,
+    step_kwargs: dict[Step, dict[str, Any]] | None = None,
     parallel_kwargs: dict[str, Any] | None = None,
     reduction_parallel_kwargs: dict[str, Any] | None = None,
+    defringe: bool | Literal['both'] = 'both',
+    flat_data_path: str = DEFAULT_FLAT_DATA_PATH,
 ) -> None:
     """
-    Run the full MIRI MRS reduction pipeline, including the standard reduction from
+    Run the full MIRI IFU reduction pipeline, including the standard reduction from
     stage0 to stage3, and custom pipeline steps for additional cleaning and data
     visualisation.
 
@@ -320,13 +277,16 @@ def run_pipeline(
 
         from miri_pipeline import run_pipeline
 
-        # Run the full pipeline, with all steps enabled
+        # Run the full pipeline with all steps enabled
         run_pipeline('/data/uranus/lon1')
+
+        # Run the full pipeline in parallel, using 50% of available cores
+        run_pipeline('/data/uranus/lon1', parallel=0.5)
 
         # Run the full pipeline, without any desaturation
         run_pipeline('/data/uranus/lon1', desaturate=False)
 
-        # Run the pipeline, including background subtraction
+        # Run the pipeline, including background subtraction in stage2
         run_pipeline(
             '/data/uranus/lon1',
             background_path='data/uranus/background',
@@ -341,859 +301,247 @@ def run_pipeline(
         # Run the pipeline, passing custom arguments to different steps
         run_pipeline(
             '/data/uranus/lon1',
-            stage3_kwargs={
-                'outlier_detection': {'snr': '30.0 24.0', 'scale': '1.3 0.7'}
+            kwargs{
+                'stage3: {
+                    'outlier_detection': {'snr': '30.0 24.0', 'scale': '1.3 0.7'}
+                },
+                'plot': {'plot_brightest_spectrum': False},
+                'animate': {'radius_factor': 2.5},
             },
-            plot_kwargs={'plot_brightest_spectrum': True},
-            animation_kwargs={'radius_factor': 2.5},
         )
 
     Args:
         root_path: Path to the root directory containing the data. This directory should
             contain a subdirectory with the stage 0 data (i.e. `root_path/stage0`).
             Additional directories will be created automatically for each step of the
-            pipeline (e.g. `root_path/stage1`, `root_path/plots` etc.).
-        defringe: Toggle defringing of the data. If True, defringe data will be saved
-            and processed. If `'both'` (the default), the pipeline will be run twice,
-            first without defringing, then again with defringing enabled. Defringed data
-            will be saved in separate directories (e.g. `root_path/stage3/d1_fringe`),
-            so both sets of data will be available for further analysis.
-        desaturate: Toggle desaturation of the data. If True, the `reduction` step will
-            be run for different numbers of groups, which are then combined in the
-            `desaturate` step to produce a desaturated data cube. If False, the
-            `reduction` step will be run only once, with the full number of groups, and
-            the `desaturate` step will be skipped (i.e. going straight to the flat field
-            step).
-        groups_to_use: List of groups to reduce and use for desaturating the data. If
-            this is `None` (the default), then all available groups will be used. If
-            `desaturate` is False, then this argument will be ignored. The data with all
-            groups will always be included.
-        background_path: Path to directory containing background data. For example, if
-            your `root_path` is `/data/uranus/lon1`, the `background_path` may
-            be `/data/uranus/background`. Note that background subtraction will
-            require the background data to be already reduced. If no `background_path`
-            is specified (the default), then no background subtraction will be
-            performed.
-        parallel: Fraction of CPU cores to use when multiprocessing. Set to 0 to run
-            serially, 1 to use all cores, 0.5 to use half of the cores, etc. If enabled,
-            multiprocessing is used in the `reduction`, `despike`, `plot` and `animate`
-            steps.
-        flat_data_path: Optionally specify custom path to the flat field data. This path
-            should contain `{channel}`, `{band}` and `{fringe}` placeholders, which will
-            be replaced by appropriate values for each channel, band and defringe
-            setting.
-        basic_navigation: Toggle between basic or full navigation. If True, then only
-            RA and Dec navigation backplanes are generated (e.g. useful for small
-            bodies). If False (the default), then full navigation is performed,
-            generating a full set of coordinate backplanes (lon/lat, illumination
-            angles etc.). Using basic navigation automatically skips the animation step.
-        skip_steps: List of steps to skip. Defaults to None. See `STEPS` above for a
-            list of valid steps. This is mainly useful if you are re-running part of the
-            pipeline.
+            pipeline (e.g. `root_path/stage1`, `root_path/plots` etc.). This is the only
+            required argument.
+
+        skip_steps: List of steps to skip.
         start_step: Convenience argument to add all steps before `start_step` to
             `skip_steps`.
         end_step: Convenience argument to add all steps after `end_step` to
             `skip_steps`.
 
-        stage1_kwargs, stage2_kwargs, defringe_kwargs, stage3_kwargs, desaturate_kwargs,
-        navigate_kwargs, flat_kwargs, despike_kwargs, background_kwargs, plot_kwargs,
-        animate_kwargs:
-            Dictionaries of arguments passed to the corresponding functions for each
-            step of the pipeline. These can therefore be used to override the default
-            values for each step. See the documentation for each function for details on
-            the arguments. See the constants (e.g. DEFAULT_STAGE1_KWARGS) above for the
-            default values.
+        parallel: Fraction of CPU cores to use when multiprocessing. Set to 0 to run
+            serially, 1 to use all cores, 0.5 to use half of the cores, etc.
+        desaturate: Toggle desaturation of the data. If True, the `stage1`-`navigate`
+            steps will be run for different numbers of groups, which are then combined
+            in the`desaturate` step to produce a desaturated data cube.
+        groups_to_use: List of groups to reduce and use for desaturating the data. If
+            this is `None` (the default), then all available groups will be used. If
+            `desaturate` is False, then this argument will be ignored. The data with all
+            groups will always be included.
+        background_subtract: Toggle background subtraction. If True, the backgrounds
+            in the `background_path` directory will be subtracted from the data in
+            `stage2`. If 'both' (the default), then versions with and without background
+            subtraction will be created.
+        background_path: Path to the directory containing the background data (i.e. the
+            equivalent of `root_path` for the background observations). Note that the
+            background data must be reduced to at least `stage1` for this to work as
+            the *_rate.fits files are used for the background subtraction.
+        basic_navigation: Toggle between basic or full navigation. If True, then only
+            RA and Dec navigation backplanes are generated (e.g. useful for small
+            bodies). If False (the default), then full navigation is performed,
+            generating a full set of coordinate backplanes (lon/lat, illumination
+            angles etc.). Using basic navigation automatically skips the animation step.
+            This is mainly useful if you get SPICE errors when navigating the data.
+        step_kwargs: Dictionary of keyword arguments to pass to each step of the
+            pipeline. The keys should be the step names (e.g. `stage1`, `stage2` etc.)
+            and the values should be dictionaries of keyword arguments to pass to the
+            step. See the documentation for each step for the available keyword
+            arguments. For example,
+            `step_kwargs={'stage3':{'outlier_detection': {'snr': '30.0 24.0', 'scale': '1.3 0.7'}}}`
+            can will customise the `stage3` step. See the DEFAULT_KWARGS constant above
+            for the default values.
+        parallel_kwargs: Dictionary of keyword arguments to customise parallel
+            processing.
+        reduction_parallel_kwargs: Dictionary of keyword arguments to customise parallel
+            processing for the reduction steps (i.e. `stage1`-`stage3`). This will be
+            merged with `parallel_kwargs` (i.e.
+            `parallel_kwargs | reduction_parallel_kwargs
+
+        defringe: Toggle defringing of the data. If True, defringe data will be saved
+            and processed. If `'both'` (the default), the pipeline steps will
+            effectively be run twice, first without defringing, then again with
+            defringing enabled. Defringed data will be saved in separate directories
+            (e.g. `root_path/stage3/d1_fringe`), so both sets of data will be available
+            for further analysis.
+        flat_data_path: Optionally specify custom path to the flat field data. This path
+            should contain `{channel}`, `{band}` and `{fringe}` placeholders, which will
+            be replaced by appropriate values for each channel, band and defringe
+            setting.
     """
-    # Process args
-    parallel_kwargs = dict(
-        parallel_frac=parallel,
-        timeout=60 * 60,
-    ) | (parallel_kwargs or {})
-    reduction_parallel_kwargs = (
-        parallel_kwargs
-        | dict(
-            start_delay=10,
-            parallel_job_kw=dict(
-                caught_error_wait_time=15,
-                caught_error_wait_time_frac=1,
-                caught_error_wait_time_max=600,
-            ),
-        )
-        | (reduction_parallel_kwargs or {})
+    pipeline = MiriPipeline(
+        root_path,
+        parallel=parallel,
+        desaturate=desaturate,
+        groups_to_use=groups_to_use,
+        background_subtract=background_subtract,
+        background_path=background_path,
+        basic_navigation=basic_navigation,
+        step_kwargs=step_kwargs,
+        parallel_kwargs=parallel_kwargs,
+        reduction_parallel_kwargs=reduction_parallel_kwargs,
+        flat_data_path=flat_data_path,
+        defringe=defringe,
+    )
+    pipeline.run(
+        skip_steps=skip_steps,
+        start_step=start_step,
+        end_step=end_step,
     )
 
-    # Process skip steps
-    if skip_steps is None:
-        skip_steps = []
-    for s in skip_steps:
-        if s not in STEPS:
-            raise ValueError(f'Invalid skip step: {s!r} (valid steps: {STEPS})')
-    skip_steps = set(skip_steps)
-    if start_step is not None:
-        if start_step not in STEPS:
-            raise ValueError(
-                f'Invalid start step: {start_step!r} (valid steps: {STEPS})'
-            )
-        skip_steps.update(STEPS[: STEPS.index(start_step)])
-    if end_step is not None:
-        if end_step not in STEPS:
-            raise ValueError(f'Invalid end step: {end_step!r} (valid steps: {STEPS})')
-        skip_steps.update(STEPS[STEPS.index(end_step) + 1 :])
-    if basic_navigation:
-        skip_steps.add('animate')
 
-    # Standardise file paths
-    root_path = os.path.expandvars(os.path.expanduser(root_path))
-    if background_path is not None:
-        background_path = os.path.expandvars(os.path.expanduser(background_path))
-    flat_data_path = os.path.expandvars(os.path.expanduser(flat_data_path))
+class MiriPipeline(Pipeline):
+    def __init__(
+        self,
+        *args,
+        flat_data_path: str,
+        defringe: bool | Literal['both'] = 'both',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.flat_data_path = self.standardise_path(flat_data_path)
+        self.defringe = defringe
 
-    # Print info
-    log('Running MIRI pipeline')
-    log(f'Root path: {root_path!r}', time=False)
-    if skip_steps:
-        log(
-            f'Skipping steps: {", ".join([repr(s) for s in STEPS if s in skip_steps])}',
-            time=False,
-        )
-    else:
-        log('Running all pipeline steps', time=False)
-    log(f'Defringe: {defringe!r}', time=False)
-    log(f'Desaturate: {desaturate!r}', time=False)
-    if groups_to_use:
-        log(f'Groups to keep: {groups_to_use!r}', time=False)
-    if basic_navigation:
-        log(f'Basic navigation: {basic_navigation!r}', time=False)
-    print()
+    @staticmethod
+    def get_instrument() -> str:
+        return 'MIRI'
 
-    # Run pipeline steps...
-    if desaturate and 'remove_groups' not in skip_steps:
-        run_remove_groups(root_path, groups_to_use)
+    @property
+    def steps(self) -> tuple[Step, ...]:
+        return STEPS
 
-    # Create list of paths to reduce (both 'main' dataset and reduced groups)
-    group_root_paths = get_group_root_paths(root_path, desaturate, groups_to_use)
-    defringe_options = [False, True] if defringe == 'both' else [defringe]
+    @property
+    def default_kwargs(self) -> dict[Step, dict[str, Any]]:
+        return DEFAULT_KWARGS
 
-    if 'stage1' not in skip_steps:
-        run_stage1(group_root_paths, stage1_kwargs, reduction_parallel_kwargs)
+    @property
+    def step_directories(self) -> dict[Step, tuple[str, str]]:
+        directories = super().step_directories | STEP_DIRECTORIES
 
-    if 'stage2' not in skip_steps:
-        run_stage2(group_root_paths, stage2_kwargs, reduction_parallel_kwargs)
+        dir_in = 'stage3_desaturated' if self.desaturate else 'stage3'
+        directories['flat'] = (dir_in, directories['flat'][1])
 
-    if defringe and 'defringe' not in skip_steps:
-        run_defringe(group_root_paths, defringe_kwargs, parallel_kwargs)
+        return directories
 
-    if 'stage3' not in skip_steps:
-        run_stage3(
-            group_root_paths, defringe_options, stage3_kwargs, reduction_parallel_kwargs
-        )
+    @property
+    def stage3_file_match_hdr_keys(self) -> tuple[str, ...]:
+        return ('CHANNEL', 'BAND')
 
-    if 'navigate' not in skip_steps:
-        run_navigate(
-            group_root_paths, defringe_options, basic_navigation, navigate_kwargs
-        )
+    @property
+    def stage_directories_to_plot(self) -> tuple[str, ...]:
+        return STAGE_DIRECTORIES_TO_PLOT
 
-    if desaturate and 'desaturate' not in skip_steps:
-        run_desaturate(
-            root_path,
-            group_root_paths,
-            defringe_options,
-            desaturate_kwargs,
-            parallel_kwargs,
-        )
+    def process_skip_steps(
+        self,
+        skip_steps: Collection[Step] | None,
+        start_step: Step | None,
+        end_step: Step | None,
+    ) -> set[Step]:
+        skip_steps = super().process_skip_steps(skip_steps, start_step, end_step)
+        if not self.defringe:
+            skip_steps.add('defringe')
+        return skip_steps
 
-    if 'flat' not in skip_steps:
-        run_flat(
-            root_path,
-            defringe_options,
-            flat_data_path,
-            flat_kwargs,
-            input_stage='stage3_desaturated' if desaturate else 'stage3',
-        )
+    @property
+    def data_variants_individual(self) -> set[str]:
+        variants = super().data_variants_individual
+        if self.defringe:
+            variants.add('fringe')
+        return variants
 
-    if 'despike' not in skip_steps:
-        run_despike(root_path, defringe_options, despike_kwargs, parallel_kwargs)
+    def print_reduction_info(self, skip_steps: set[Step]) -> None:
+        super().print_reduction_info(skip_steps)
+        self.log(f'Defringe: {self.defringe!r}', time=False)
+        self.log(f'Flat data path: {self.flat_data_path!r}', time=False)
 
-    if background_path is not None and 'background' not in skip_steps:
-        run_background(root_path, defringe_options, background_path, background_kwargs)
+    # Step overrides
+    def reduction_detector1_fn(self, args: tuple[str, str, dict[str, Any]]) -> None:
+        path_in, output_dir, kwargs = args
+        kwargs = kwargs.copy()
+        with fits.open(path_in) as hdul:
+            ngroups = hdul['PRIMARY'].header['NGROUPS']  # type: ignore
+        if ngroups <= 3:
+            kwargs['steps'] = kwargs.get('steps', {}) | {
+                'firstframe': {'skip': True},
+                'lastframe': {'skip': True},
+                'rscd': {'skip': True},
+                'jump': {'skip': True},
+            }
+        return super().reduction_detector1_fn((path_in, output_dir, kwargs))
 
-    if 'plot' not in skip_steps:
-        run_plot(group_root_paths, defringe_options, plot_kwargs, parallel_kwargs)
-
-    if 'animate' not in skip_steps:
-        run_animate(root_path, defringe_options, animate_kwargs, parallel_kwargs)
-
-    log('MIRI pipeline completed with')
-    log(f'Root path: {root_path!r}', time=False)
-    log(f'Defringe: {defringe!r}', time=False)
-    log(f'Desaturate: {desaturate!r}', time=False)
-    if skip_steps:
-        log(
-            f'Skipped steps: {", ".join([repr(s) for s in STEPS if s in skip_steps])}',
-            time=False,
-        )
-    log('ALL DONE')
-
-
-# remove groups
-def run_remove_groups(root_path: str, groups_to_use: list[int] | None = None) -> None:
-    log('Removing groups')
-    paths_in = sorted(glob.glob(os.path.join(root_path, 'stage0', '*_uncal.fits')))
-    log(f'Processing {len(paths_in)} files...', time=False)
-    for p in tqdm.tqdm(paths_in, desc='remove_groups'):
-        remove_groups.remove_groups_from_file(p, groups_to_use)
-    log('Remove groups step complete\n')
-
-
-def get_group_root_paths(
-    root_path: str, desaturate: bool, groups_to_use: list[int] | None = None
-) -> list[str]:
-    group_root_paths = [root_path]
-    if desaturate:
-        # If desaturating, we also need to reduce the data with fewer groups
-        # This list is sorted such that the number of groups is decreasing (so that the
-        # desaturation works correctly)
-        reduced_group_root_paths = sorted(
-            glob.glob(os.path.join(root_path, 'groups', '*_groups')),
-            reverse=True,
-            key=lambda _p: int(os.path.basename(_p).split('_')[0]),
-        )
-        if groups_to_use is not None:
-            reduced_group_root_paths = [
-                _p
-                for _p in reduced_group_root_paths
-                if int(os.path.basename(_p).split('_')[0]) in groups_to_use
-            ]
-        group_root_paths.extend(reduced_group_root_paths)
-    return group_root_paths
-
-
-# stage1
-def run_stage1(
-    group_root_paths: list[str],
-    stage1_kwargs: dict[str, Any] | None = None,
-    reduction_parallel_kwargs: dict[str, Any] | None = None,
-):
-    log('Running reduction stage 1')
-    kwargs = DEFAULT_STAGE1_KWARGS | (stage1_kwargs or {})
-    log(f'Arguments: {kwargs!r}', time=False)
-    for root_path in group_root_paths:
-        if len(group_root_paths) > 1:
-            log(f'Running reduction stage 1 for {root_path!r}')
-        paths_in = sorted(glob.glob(os.path.join(root_path, 'stage0', '*.fits')))
-        output_dir = os.path.join(root_path, 'stage1')
-        args_list = [(p, output_dir, kwargs) for p in paths_in]
-        log(f'Output directory: {output_dir!r}', time=False)
-        log(f'Processing {len(args_list)} files...', time=False)
-        check_path(output_dir)
-        runmany(
-            reduction_detector1_fn,
-            args_list,
-            desc='stage1',
-            **reduction_parallel_kwargs or {},
-        )
-    log('Reduction stage 1 step complete\n')
-
-
-def reduction_detector1_fn(args: tuple[str, str, dict[str, Any]]) -> None:
-    path_in, output_dir, kwargs = args
-
-    with fits.open(path_in) as hdul:
-        ngroups = hdul['PRIMARY'].header['NGROUPS']  # type: ignore
-    if ngroups <= 3:
-        kwargs['steps'] = kwargs.get('steps', {}) | {
-            'firstframe': {'skip': True},
-            'lastframe': {'skip': True},
-            'rscd': {'skip': True},
-            'jump': {'skip': True},
-        }
-
-    Detector1Pipeline.call(path_in, output_dir=output_dir, save_results=True, **kwargs)
-
-
-# stage2
-def run_stage2(
-    group_root_paths: list[str],
-    stage2_kwargs: dict[str, Any] | None = None,
-    reduction_parallel_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running reduction stage 2')
-    kwargs = DEFAULT_STAGE2_KWARGS | (stage2_kwargs or {})
-    log(f'Arguments: {kwargs!r}', time=False)
-    for root_path in group_root_paths:
-        if len(group_root_paths) > 1:
-            log(f'Running reduction stage 2 for {root_path!r}')
-        paths_in = sorted(glob.glob(os.path.join(root_path, 'stage1', '*rate.fits')))
-        output_dir = os.path.join(root_path, 'stage2')
-        args_list = [(p, output_dir, kwargs) for p in paths_in]
-        log(f'Output directory: {output_dir!r}', time=False)
-        log(f'Processing {len(args_list)} files...', time=False)
-        check_path(output_dir)
-        runmany(
-            reduction_spec2_fn,
-            args_list,
-            desc='stage2',
-            **reduction_parallel_kwargs or {},
-        )
-    log('Reduction stage 2 step complete\n')
-
-
-def reduction_spec2_fn(args: tuple[str, str, dict[str, Any]]) -> None:
-    path_in, output_dir, kwargs = args
-    Spec2Pipeline.call(path_in, output_dir=output_dir, save_results=True, **kwargs)
-
-
-# defringe
-def run_defringe(
-    group_root_paths: list[str],
-    defringe_kwargs: dict[str, Any] | None = None,
-    reduction_parallel_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running reduction defringe')
-    kwargs = DEFAULT_DEFRINGE_KWARGS | (defringe_kwargs or {})
-    log(f'Arguments: {kwargs!r}', time=False)
-    for root_path in group_root_paths:
-        if len(group_root_paths) > 1:
-            log(f'Running defringe for {root_path!r}')
-        paths_in = sorted(glob.glob(os.path.join(root_path, 'stage2', '*cal.fits')))
-        output_dir = os.path.join(root_path, 'stage2')
-        args_list = [(p, output_dir, kwargs) for p in paths_in]
-        log(f'Output directory: {output_dir!r}', time=False)
-        log(f'Processing {len(args_list)} files...', time=False)
-        check_path(output_dir)
-        runmany(
-            defringe_fn,
-            args_list,
-            desc='defringe',
-            **reduction_parallel_kwargs or {},
-        )
-    log('Defringe step complete\n')
-
-
-def defringe_fn(args: tuple[str, str, dict[str, Any]]) -> None:
-    path_in, output_dir, kwargs = args
-    ResidualFringeStep.call(path_in, output_dir=output_dir, save_results=True, **kwargs)
-
-
-# stage3
-def run_stage3(
-    group_root_paths: list[str],
-    defringe_options: list[bool],
-    stage3_kwargs: dict[str, Any] | None = None,
-    reduction_parallel_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running reduction stage 3')
-    kwargs = DEFAULT_STAGE3_KWARGS | (stage3_kwargs or {})
-    log(f'Arguments: {kwargs!r}', time=False)
-
-    for defringe in defringe_options:
-        for root_path in group_root_paths:
-            log(f'Running reduction stage 3 for defringe={defringe} on {root_path!r}')
-            grouped_files = group_stage2_files_for_stage3(root_path, defringe)
-
-            # Only need to include the tile in prodname if it is needed to avoid filename
-            # collisions for observations which use mosaicing. Most observations just have a
-            # single tile per datset, so we can just use the standard prodname in this case
-            keys_with_tiles = set(grouped_files.keys())
-            keys_without_tiles = set(
-                (dither, channel, band)
-                for dither, tile, channel, band in keys_with_tiles
-            )
-            include_tile_in_prodname = len(keys_with_tiles) != len(keys_without_tiles)
-
-            asn_paths_list: list[tuple[str, str]] = []
-            for (dither, tile, channel, band), paths in grouped_files.items():
-                dirname = 'combined' if dither is None else f'd{dither}'
-                if defringe:
-                    dirname += '_fringe'
-                output_dir = os.path.join(root_path, 'stage3', dirname)
-                check_path(output_dir)
-                asn_path = os.path.join(
-                    output_dir, f'l3asn-{tile}_{channel}_{band}_dither-{dirname}.json'
-                )
-                write_asn_for_stage3(
-                    paths,
-                    asn_path,
-                    prodname='Level3'
-                    + (f'_{tile}' if include_tile_in_prodname else ''),
-                )
-                asn_paths_list.append((asn_path, output_dir))
-            args_list = [
-                (p, output_dir, kwargs) for p, output_dir in sorted(asn_paths_list)
-            ]
-            log(f'Processing {len(args_list)} files...', time=False)
+    def run_defringe(self, kwargs: dict[str, Any]) -> None:
+        dir_in, dir_out = self.step_directories['defringe']
+        for root_path in self.iterate_group_root_paths():
+            paths_in = self.get_paths(root_path, dir_in, '*cal.fits')
+            if 'bg' in self.data_variants_individual:
+                paths_in += self.get_paths(root_path, dir_in, 'bg', '*cal.fits')
+            args_list = [(p, os.path.basename(p), kwargs) for p in paths_in]
+            self.log(f'Processing {len(args_list)} files...', time=False)
             runmany(
-                reduction_spec3_fn,
+                self.defringe_fn,
                 args_list,
-                desc='stage3',
-                **reduction_parallel_kwargs or {},
+                desc='defringe',
+                **self.reduction_parallel_kwargs,
             )
-    log('Reduction stage 3 step complete\n')
 
-
-def group_stage2_files_for_stage3(
-    root_path: str,
-    defringe: bool,
-) -> dict[tuple[int | None, str, str, str], list[str]]:
-    out: dict[tuple[int | None, str, str, str], list[str]] = {}
-    suffix = 'residual_fringe.fits' if defringe else 'cal.fits'
-    paths_in = sorted(glob.glob(os.path.join(root_path, 'stage2', f'*{suffix}')))
-    for p in paths_in:
-        with fits.open(p) as hdul:
-            hdr = hdul[0].header  #  type: ignore
-        dither = int(hdr['PATT_NUM'])
-        tile = hdr['ACT_ID']
-        channel = hdr['CHANNEL']
-        band = hdr['BAND']
-
-        # Keep dithers separate
-        k = (dither, tile, channel, band)
-        out.setdefault(k, []).append(p)
-
-        # Combine dithers
-        k = (None, tile, channel, band)
-        out.setdefault(k, []).append(p)
-    return out
-
-
-def write_asn_for_stage3(
-    files: list[str], asnfile: str, prodname: str, **kwargs
-) -> None:
-    asn = asn_from_list(files, rule=DMS_Level3_Base, product_name=prodname)
-    if 'bg' in kwargs:
-        for bgfile in kwargs['bg']:
-            asn['products'][0]['members'].append(
-                {'expname': bgfile, 'exptype': 'background'}
-            )
-    _, serialized = asn.dump()
-    with open(asnfile, 'w', encoding='utf-8') as outfile:
-        outfile.write(serialized)
-
-
-def reduction_spec3_fn(args: tuple[str, str, dict[str, Any]]) -> None:
-    asn_path, output_dir, kwargs = args
-    Spec3Pipeline.call(
-        asn_path,
-        output_dir=output_dir,
-        save_results=True,
-        **kwargs,
-    )
-
-
-# navigation
-def run_navigate(
-    group_root_paths: list[str],
-    defringe_options: list[bool],
-    basic_navigation: bool = False,
-    navigate_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running navigate')
-    kwargs = DEFAULT_NAVIGATE_KWARGS | (navigate_kwargs or {})
-    log(f'Basic navigation: {basic_navigation!r}', time=False)
-    log(f'Arguments: {kwargs!r}', time=False)
-    navigate_jwst_observations.load_kernels()
-    for defringe in defringe_options:
-        for root_path in group_root_paths:
-            log(f'Running navigation for defringe={defringe} on {root_path!r}')
-            paths_in = sorted(
-                filter_paths_by_defringe(
-                    glob.glob(os.path.join(root_path, 'stage3', '*', '*_s3d.fits')),
-                    defringe,
-                )
-            )
-            navigate_jwst_observations.navigate_multiple(
-                *paths_in, basic=basic_navigation, **kwargs
-            )
-    log('Navigate step complete\n')
-
-
-# desaturate
-def run_desaturate(
-    root_path: str,
-    group_root_paths: list[str],
-    defringe_options: list[bool],
-    desaturate_kwargs: dict[str, Any] | None = None,
-    parallel_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running desaturate')
-    kwargs = DEFAULT_DESATURATE_KWARGS | (desaturate_kwargs or {})
-    parallel_kwargs = parallel_kwargs or {}
-    log(f'Arguments: {kwargs!r}', time=False)
-
-    for defringe in defringe_options:
-        log(f'Running desaturation for defringe={defringe!r}')
-        paths_dict: dict[str, list[str]] = {}
-        for rp in group_root_paths:
-            paths_in = sorted(
-                filter_paths_by_defringe(
-                    glob.glob(os.path.join(rp, 'stage3', '*_nav', '*_nav.fits')),
-                    defringe,
-                )
-            )
-            for p_in in paths_in:
-                relpath = os.path.relpath(p_in, rp)
-                relpath = replace_path_part(
-                    relpath, -3, 'stage3_desaturated', check_old='stage3'
-                )
-                p_out = os.path.join(root_path, relpath)
-                paths_dict.setdefault(p_out, []).append(p_in)
-        args_list = [
-            (paths_in, p_out, kwargs) for p_out, paths_in in paths_dict.items()
-        ]
-        log(f'Processing {len(args_list)} output files...', time=False)
-        runmany(desaturate_fn, args_list, desc='desaturate', **parallel_kwargs)
-    log('Desaturate step complete\n')
-
-
-def desaturate_fn(args: tuple[list[str], str, dict[str, Any]]) -> None:
-    paths_in, path_out, kwargs = args
-    desaturate_data.replace_saturated(paths_in, path_out, **kwargs)
-
-
-# flat
-def run_flat(
-    root_path: str,
-    defringe_options: list[bool],
-    flat_data_path: str,
-    flat_kwargs: dict[str, Any] | None = None,
-    input_stage: str = 'stage3',
-) -> None:
-    log('Running flat')
-    kwargs = DEFAULT_FLAT_KWARGS | (flat_kwargs or {})
-    log(f'Arguments: {kwargs!r}', time=False)
-    log(f'Flat data path: {flat_data_path!r}', time=False)
-
-    for defringe in defringe_options:
-        log(f'Running flat for defringe={defringe!r}')
-        paths_in = sorted(
-            filter_paths_by_defringe(
-                glob.glob(os.path.join(root_path, input_stage, 'd*_nav', '*_nav.fits')),
-                defringe,
-            )
+    def defringe_fn(self, args: tuple[str, str, dict[str, Any]]) -> None:
+        path_in, output_dir, kwargs = args
+        ResidualFringeStep.call(
+            path_in, output_dir=output_dir, save_results=True, **kwargs
         )
-        log(f'Processing {len(paths_in)} input files...', time=False)
+
+    def get_stage3_variant_paths_in(self, variant: frozenset[str]) -> list[str]:
+        """
+        Get list of input paths for a given variant for stage3.
+        """
+        dir_in, dir_out = self.step_directories['stage3']
+        if variant == frozenset():
+            return self.get_paths(dir_in, '*cal.fits')
+        elif variant == frozenset({'bg'}):
+            return self.get_paths(dir_in, 'bg', '*cal.fits')
+        elif variant == frozenset({'bg', 'fringe'}):
+            return self.get_paths(dir_in, 'bg', '*residual_fringe.fits')
+        elif variant == frozenset({'fringe'}):
+            return self.get_paths(dir_in, '*residual_fringe.fits')
+        raise ValueError(f'Unknown variant: {variant}')
+
+    def run_flat(self, kwargs: dict[str, Any]) -> None:
+        dir_in, dir_out = self.step_directories['flat']
+        self.log(f'Flat data path: {self.flat_data_path!r}', time=False)
+        # Use d* to skip dither combined files
+        paths_in = self.get_paths(dir_in, 'd*', '*_nav.fits', filter_variants=True)
+        self.log(f'Processing {len(paths_in)} files...', time=False)
         for p_in in tqdm.tqdm(paths_in, desc='flat'):
-            p_out = replace_path_part(p_in, -3, 'stage4_flat', check_old=input_stage)
+            p_out = self.replace_path_part(p_in, -3, dir_out, old=dir_in)
             with fits.open(p_in) as hdul:
                 hdr = hdul['PRIMARY'].header  #  type: ignore
-            p_flat = flat_data_path.format(
+            p_flat = self.flat_data_path.format(
                 channel=hdr['CHANNEL'],
                 band=hdr['BAND'].lower(),
-                fringe='_fringe' if defringe else '',
+                fringe='_fringe' if hdr['S_RESFRI'] == 'COMPLETE' else '',
             )
             flat_field.apply_flat(p_in, p_out, p_flat, **kwargs)
-    log('Flat step complete\n')
 
-
-# despike
-def run_despike(
-    root_path: str,
-    defringe_options: list[bool],
-    despike_kwargs: dict[str, Any] | None = None,
-    parallel_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running despike')
-    parallel_kwargs = parallel_kwargs or {}
-    kwargs = DEFAULT_DESPIKE_KWARGS | (despike_kwargs or {})
-    if parallel_kwargs.get('parallel_frac', False):
-        kwargs.setdefault('progress_bar', False)
-    log(f'Arguments: {kwargs!r}', time=False)
-
-    for defringe in defringe_options:
-        log(f'Running despike for defringe={defringe!r}')
-        paths_in = sorted(
-            filter_paths_by_defringe(
-                glob.glob(
-                    os.path.join(root_path, 'stage4_flat', '*_nav', '*_nav.fits')
-                ),
-                defringe,
-            )
-        )
-        paths_out = [
-            replace_path_part(p, -3, 'stage5_despike', check_old='stage4_flat')
-            for p in paths_in
-        ]
-        args_list = [(p_in, p_out, kwargs) for p_in, p_out in zip(paths_in, paths_out)]
-        log(f'Processing {len(args_list)} files...', time=False)
-        runmany(despike_fn, args_list, desc='despike', **parallel_kwargs)
-    log('Despike step complete\n')
-
-
-def despike_fn(args: tuple[str, str, dict[str, Any]]) -> None:
-    p_in, p_out, kwargs = args
-    despike_data.despike_cube(p_in, p_out, **kwargs)
-
-
-# background
-def run_background(
-    root_path: str,
-    defringe_options: list[bool],
-    background_path: str,
-    background_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running background')
-    kwargs = DEFAULT_BACKGROUND_KWARGS | (background_kwargs or {})
-    log(f'Arguments: {kwargs!r}', time=False)
-
-    for defringe in defringe_options:
-        log(f'Running background subtraction for defringe={defringe!r}')
-        paths_in = sorted(
-            filter_paths_by_defringe(
-                glob.glob(
-                    os.path.join(root_path, 'stage5_despike', '*_nav', '*_nav.fits')
-                ),
-                defringe,
-            )
-        )
-        log(f'Processing {len(paths_in)} input files...', time=False)
-        for p_in in tqdm.tqdm(paths_in, desc='background'):
-            p_out = replace_path_part(
-                p_in, -3, 'stage6_background', check_old='stage5_despike'
-            )
-            with fits.open(p_in) as hdul:
-                hdr = hdul['PRIMARY'].header  #  type: ignore
-            p_background = os.path.join(
-                background_path,
-                'stage5_despike',
-                'd{dither}{fringe}_nav',
-                'Level3_ch{channel}-{band}_s3d_nav.fits',
-            ).format(
-                channel=hdr['CHANNEL'],
-                band=hdr['BAND'].lower(),
-                fringe='_fringe' if defringe else '',
-                dither='1',
-            )
-            background_subtraction.subtract_background(
-                p_in, p_out, p_background, **kwargs
-            )
-    log('Background step complete\n')
-
-
-# plot
-def run_plot(
-    group_root_paths: list[str],
-    defringe_options: list[bool],
-    plot_kwargs: dict[str, Any] | None = None,
-    parallel_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running plot')
-    kwargs = DEFAULT_PLOT_KWARGS | (plot_kwargs or {})
-    parallel_kwargs = parallel_kwargs or {}
-    log(f'Arguments: {kwargs!r}', time=False)
-
-    for defringe in defringe_options:
-        for root_path in group_root_paths:
-            log(f'Generating quick look plots for defringe={defringe} on {root_path!r}')
-            for stage in reversed(DATA_STAGES):
-                log(f'Generating quick look plots for stage {stage!r}')
-                paths_in = sorted(
-                    filter_paths_by_defringe(
-                        glob.glob(
-                            os.path.join(root_path, stage, '*_nav', '*_nav.fits')
-                        ),
-                        defringe,
-                    )
-                )
-                paths_out = []
-                for p_in in paths_in:
-                    dir_out = os.path.dirname(
-                        replace_path_part(
-                            p_in, -3, os.path.join('plots', stage), check_old=stage
-                        )
-                    )
-                    filename_out = '{prefix}_{filename}'.format(
-                        prefix=get_channel_band_prefix(p_in),
-                        filename=os.path.basename(
-                            replace_path_suffix(p_in, '.png', check_old='.fits')
-                        ),
-                    )
-                    p_out = os.path.join(dir_out, filename_out)
-                    paths_out.append(p_out)
-
-                args_list = [
-                    (p_in, p_out, kwargs) for p_in, p_out in zip(paths_in, paths_out)
-                ]
-                log(f'Processing {len(args_list)} files...', time=False)
-                runmany(plot_fn, args_list, desc='plot', **parallel_kwargs)
-    log('Plot step complete\n')
-
-
-def plot_fn(args: tuple[str, str, dict[str, Any]]) -> None:
-    p_in, p_out, kwargs = args
-    jwst_summary_plots.make_summary_plot(p_in, p_out, **kwargs)
-
-
-# animate
-def run_animate(
-    root_path: str,
-    defringe_options: list[bool],
-    animate_kwargs: dict[str, Any] | None = None,
-    parallel_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running animate')
-    kwargs = DEFAULT_ANIMATE_KWARGS | (animate_kwargs or {})
-    parallel_kwargs = parallel_kwargs or {}
-    if parallel_kwargs.get('parallel_frac', False):
-        kwargs.setdefault('progress_bar', False)
-    log(f'Arguments: {kwargs!r}', time=False)
-    for defringe in defringe_options:
-        for stage in reversed(DATA_STAGES):
-            log(
-                f'Generating quick look animations for stage {stage!r}, defringe={defringe!r}'
-            )
-            paths_in = sorted(
-                filter_paths_by_defringe(
-                    glob.glob(os.path.join(root_path, stage, 'd*_nav', '*_nav.fits')),
-                    defringe,
-                )
-            )
-            paths_dict: dict[str, list[str]] = {}
-            for p_in in paths_in:
-                filename = f'{get_channel_band_prefix(p_in)}_animation.mp4'
-                fringe_directory = 'dither_comparison' + ('_fringe' if defringe else '')
-                p_out = os.path.join(
-                    root_path, 'animation', stage, fringe_directory, filename
-                )
-                paths_dict.setdefault(p_out, []).append(p_in)
-            args_list = [
-                (paths_in, p_out, kwargs) for p_out, paths_in in paths_dict.items()
-            ]
-            log(f'Processing {len(args_list)} files...', time=False)
-            runmany(animation_fn, args_list, desc='animate', **parallel_kwargs)
-    log('Animate step complete\n')
-
-
-def animation_fn(args: tuple[list[str], str, dict[str, Any]]) -> None:
-    paths_in, p_out, kwargs = args
-    jwst_summary_animation.make_animation(paths_in, p_out, **kwargs)
-
-
-# utils
-def filter_paths_by_defringe(paths: list[str], defringe: bool) -> list[str]:
-    # Return paths matching .../*_fringe*/* if defringe=True
-    return [p for p in paths if ('_fringe' in pathlib.Path(p).parts[-2]) == defringe]
-
-
-def replace_path_part(
-    path: str, idx: int, new: str, *, check_old: str | None = None
-) -> str:
-    """
-    Replace a part of a path with a new value.
-
-    Args:
-        path: The path to modify.
-        idx: The index of the part to replace in the directory tree.
-        new: The new value to use.
-        check_old: If not None, check that the value at the index is this value
-            before replacing it.
-
-    Returns:
-        The modified path.
-    """
-    p = pathlib.Path(path)
-    parts = list(p.parts)
-    if check_old is not None and parts[idx] != check_old:
-        raise ValueError(f'Expected {check_old!r} at index {idx} in {path!r}')
-    parts[idx] = new
-    return str(pathlib.Path(*parts))
-
-
-def replace_path_suffix(path: str, new: str, *, check_old: str | None = None) -> str:
-    """
-    Replace the suffix of a path with a new value.
-
-    Args:
-        path: The path to modify.
-        new: The new value to use.
-        check_old: If not None, check that the suffix is this value before
-            replacing it.
-
-    Returns:
-        The modified path.
-    """
-    p = pathlib.Path(path)
-    if check_old is not None and p.suffix != check_old:
-        raise ValueError(f'Expected {check_old!r} suffix in {path!r}')
-    return str(p.with_suffix(new))
-
-
-def get_channel_band_prefix(path: str) -> str:
-    """
-    Get channel-band prefix for a MIRI cube (e.g. '1B', '4C' etc.)
-    """
-    with fits.open(path) as hdul:
-        hdr = hdul['PRIMARY'].header  #  type: ignore
-    channel = hdr['CHANNEL']
-    abc = MIRI_BAND_ABC_ALIASES[hdr['BAND'].casefold().strip()]
-    return f'{channel}{abc}'
+    def get_plot_filename_prefix(self, path: str) -> str:
+        with fits.open(path) as hdul:
+            hdr = hdul['PRIMARY'].header  #  type: ignore
+        channel = hdr['CHANNEL']
+        abc = BAND_ABC_ALIASES[hdr['BAND'].casefold().strip()]
+        return f'{channel}{abc}'
 
 
 def main():
-    # Parse command line arguments
-    parser = argparse.ArgumentParser(
-        description=(
-            'Full JWST MIRI pipeline including the standard reduction from stage0 to '
-            'stage3, and custom pipeline steps for additional cleaning and data '
-            'visualisation. For more customisation, this script can be imported and '
-            'run in Python (see the source code for mode details).\n\n'
-            'The following steps are run in the full pipeline:' + STEP_DESCRIPTIONS
-        ),
-        epilog=CLI_EXAMPLES,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        argument_default=argparse.SUPPRESS,
-    )
-    parser.add_argument(
-        'root_path',
-        type=str,
-        help="""Path to the directory containing the data. This directory should
-            contain a subdirectory with the stage0 data (i.e. `root_path/stage0`).
-            Additional directories will be created automatically for each step of the
-            pipeline (e.g. `root_path/stage1`, `root_path/plots` etc.).""",
-    )
+    parser = get_pipeline_argument_parser(MiriPipeline, STEP_DESCRIPTIONS, CLI_EXAMPLES)
     parser.add_argument(
         '--defringe',
         action=argparse.BooleanOptionalAction,
         default='both',
-        help="""Toggle defringing of the data. If unspecified, the pipeline will be run 
-            twice, first without defringing, then again with defringing enabled.""",
-    )
-    parser.add_argument(
-        '--desaturate',
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="""Toggle desaturation of the data. If desaturation is enabled the 
-            `reduction` step will be run for different numbers of groups, which are then
-            combined in the `desaturate` step to produce a desaturated data cube. This
-            desaturation is enabled by default.
-            """,
-    )
-    parser.add_argument(
-        '--groups_to_use',
-        type=str,
-        help="""Comma-separated list of groups to keep. For example, `1,2,3,4` will
-            keep the first four groups. If unspecified, all groups will be kept.""",
-    )
-    parser.add_argument(
-        '--background_path',
-        type=str,
-        help="""Path to directory containing background data. For example, if
-            your `root_path` is `/data/uranus/lon1`, the `background_path` may
-            be `/data/uranus/background`. Note that background subtraction will
-            require the background data to be already reduced. If no `background_path`
-            is specified (the default), then no background subtraction will be 
-            performed.""",
-    )
-    parser.add_argument(
-        '--parallel',
-        nargs='?',
-        const=1,
-        type=float,
-        help="""Fraction of CPU cores to use when multiprocessing. For example, set 
-        0.5 to use half of the available cores. If unspecified, then multiprocessing 
-        will not be used and the pipeline will be run serially. If specified but no 
-        value is given, then all available cores will be used (i.e. `--parallel` is 
-        equivalent to `--parallel 1`). If enabled, multiprocessing is used in the 
-        `reduction`, `despike`, `plot` and `animate` steps.""",
+        help="""Toggle defringing of the data. If unspecified, the pipeline steps will
+            effectively be run twice, first without defringing, then again with
+            defringing enabled.""",
     )
     parser.add_argument(
         '--flat_data_path',
@@ -1203,54 +551,7 @@ def main():
             be replaced by appropriate values for each channel, band and defringe
             setting.""",
     )
-    parser.add_argument(
-        '--basic_navigation',
-        action='store_true',
-        help="""Use basic navigation, and only save RA and Dec backplanes (e.g. useful
-            for small bodies). By default, full navigation is performed, generating a
-            full set of coordinate backplanes (lon/lat, illumination angles etc.). Using
-            basic navigation automatically skips the navigation step.""",
-    )
-    parser.add_argument(
-        '--skip_steps',
-        nargs='+',
-        type=str,
-        help="""List of steps to skip. This is generally only useful if you are
-            re-running part of the pipeline. Multiple steps can be passed as a
-            space-separated list. For example, `--skip_steps flat despike`.""",
-    )
-    parser.add_argument(
-        '--start_step',
-        type=str,
-        help="""Convenience argument to add all steps before `start_step` to 
-            `skip_steps`.""",
-    )
-    parser.add_argument(
-        '--end_step',
-        type=str,
-        help="""Convenience argument to add all steps steps after `end_step` to 
-            `skip_steps`.""",
-    )
-    parser.add_argument(
-        '--kwargs',
-        type=str,
-        help="""JSON string containing keyword arguments to pass to individual pipeline
-            steps. For example, 
-            `--kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "animation": {"radius_factor": 2.5}}'` 
-            will pass the custom arguments to the stage3 and animation steps.
-            """,
-    )
-    args = vars(parser.parse_args())
-    json_kwargs = args.pop('kwargs', None)
-    if json_kwargs:
-        json_kwargs = json.loads(json_kwargs)
-        for k, v in json_kwargs.items():
-            if not k.endswith('_kwargs'):
-                k = k + '_kwargs'
-            args[k] = v
-    if 'groups_to_use' in args:
-        args['groups_to_use'] = [int(g) for g in args['groups_to_use'].split(',')]
-    run_pipeline(**args)
+    run_pipeline(**vars(parser.parse_args()))
 
 
 if __name__ == '__main__':

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -235,13 +235,19 @@ BAND_ABC_ALIASES = {'short': 'A', 'medium': 'B', 'long': 'C'}
 
 # Try to get a useful default flat data path that at least works natively on Leicester's
 # ALICE HPC
+_filename = 'ch{channel}-{band}_constructed_flat{fringe}.fits'
 _path_options = (
-    '/data/nemesis/jwst/MIRI_IFU/flat_field',
+    os.path.join('/data/nemesis/jwst/MIRI_IFU/flat_field', _filename),
     os.path.join(
-        os.path.dirname(__file__), '..', 'jwst_data', 'MIRI_IFU', 'flat_field'
+        os.path.dirname(__file__),
+        '..',
+        'jwst_data',
+        'MIRI_IFU',
+        'flat_field',
+        _filename,
     ),
-    os.path.join(os.path.dirname(__file__), '..', 'jwst_data', 'flat_field'),
-    os.path.join(os.path.dirname(__file__), 'flat_field'),
+    os.path.join(os.path.dirname(__file__), '..', 'jwst_data', 'flat_field', _filename),
+    os.path.join(os.path.dirname(__file__), 'flat_field', _filename),
 )
 DEFAULT_FLAT_DATA_PATH = _path_options[-1]
 for _p in _path_options:

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -446,7 +446,7 @@ class MiriPipeline(Pipeline):
         start_step: Step | None,
         end_step: Step | None,
     ) -> set[Step]:
-        skip_steps = super().process_steps_list(skip_steps, start_step, end_step)
+        skip_steps = super().process_skip_steps(skip_steps, start_step, end_step)
         if not self.defringe:
             skip_steps.add('defringe')
         return skip_steps
@@ -535,7 +535,7 @@ class MiriPipeline(Pipeline):
             hdr = hdul['PRIMARY'].header  #  type: ignore
         channel = hdr['CHANNEL']
         abc = BAND_ABC_ALIASES[hdr['BAND'].casefold().strip()]
-        return f'{channel}{abc}'
+        return f'{channel}{abc}_'
 
 
 def main():

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -490,7 +490,7 @@ class MiriPipeline(Pipeline):
     def defringe_fn(self, args: tuple[str, str, dict[str, Any]]) -> None:
         path_in, output_dir, kwargs = args
         ResidualFringeStep.call(
-            path_in, output_dir=output_dir, save_results=True, **kwargs
+            path_in, output_dir=output_dir, save_results=True, skip=False, **kwargs
         )
 
     def get_stage3_variant_paths_in(self, variant: frozenset[str]) -> list[str]:

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -163,7 +163,7 @@ python3 miri_pipeline.py /data/uranus/lon1 --no-desaturate
 python3 miri_pipeline.py /data/uranus/lon1 --defringe
 
 # Run the pipeline, including background subtraction
-python3 miri_pipeline.py /data/uranus/lon1 --background_path /data/saturn/SATURN-BACKGROUND
+python3 miri_pipeline.py /data/uranus/lon1 --background_path /data/uranus/background
 
 # Run the pipeline, but stop before creating any visualisations
 python3 miri_pipeline.py /data/uranus/lon1 --end_step despike
@@ -394,7 +394,8 @@ def run_pipeline(
             `skip_steps`.
 
         stage1_kwargs, stage2_kwargs, defringe_kwargs, stage3_kwargs, desaturate_kwargs,
-        navigate_kwargs, flat_kwargs, despike_kwargs, plot_kwargs, animate_kwargs:
+        navigate_kwargs, flat_kwargs, despike_kwargs, background_kwargs, plot_kwargs,
+        animate_kwargs:
             Dictionaries of arguments passed to the corresponding functions for each
             step of the pipeline. These can therefore be used to override the default
             values for each step. See the documentation for each function for details on
@@ -954,8 +955,8 @@ def run_background(
                 'd{dither}{fringe}_nav',
                 'Level3_ch{channel}-{band}_s3d_nav.fits',
             ).format(
-                channel=hdr['CHANNEL'],
-                band=hdr['BAND'],
+                channel=hdr['CHANNEL'].lower(),
+                band=hdr['BAND'].lower(),
                 fringe='_fringe' if defringe else '',
                 dither='1',
             )

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -110,7 +110,7 @@ To use this script you will need to:
 
     #!/bin/bash
     #
-    #PBS -N Pipeline
+    #PBS -N MIRI_Pipeline
     #PBS -l walltime=24:00:00
     #PBS -l vmem=80gb
     #PBS -l nodes=1:ppn=8

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -484,8 +484,7 @@ class MiriPipeline(Pipeline):
             paths_in = self.get_paths(root_path, dir_in, '*cal.fits')
             if 'bg' in self.data_variants_individual:
                 paths_in += self.get_paths(root_path, dir_in, 'bg', '*cal.fits')
-            args_list = [(p, os.path.basename(p), kwargs) for p in paths_in]
-            self.log(f'Processing {len(args_list)} files...', time=False)
+            args_list = [(p, os.path.dirname(p), kwargs) for p in paths_in]
             runmany(
                 self.defringe_fn,
                 args_list,

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -708,7 +708,7 @@ def run_stage3(
                 output_dir = os.path.join(root_path, 'stage3', dirname)
                 check_path(output_dir)
                 asn_path = os.path.join(
-                    output_dir, f'l3asn-{tile}_{channel}_{band}_dither-{dither}.json'
+                    output_dir, f'l3asn-{tile}_{channel}_{band}_dither-{dirname}.json'
                 )
                 write_asn_for_stage3(
                     paths,

--- a/miri_pipeline_old.py
+++ b/miri_pipeline_old.py
@@ -1,0 +1,874 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This old version of the MIRI pipeline is kept for backwards compatibility. It is
+only kept here for reference and backwards compatibility. All new development should
+be done in miri_pipeline.py.
+
+
+
+Full JWST reduction pipeline for MIRI MRS data, including the standard reduction from 
+stage0 to stage3, and custom pipeline steps for additional cleaning and data 
+visualisation.
+
+See STEP_DESCRIPTIONS below for a description of each step in this pipeline.
+
+
+Setup
+=====
+If you are running a reduction on Leicester's ALICE HPC then the pipeline should work 
+out of the box without any additional setup - see the example job submission script 
+below. If you are running the pipeline on another machine, you will need to set up the
+correct environment to run the pipeline:
+
+The `reduction` step of the pipeline requires the following environment variables to be
+set to load the and cache the appropriate CRDS reference files ::
+
+    export CRDS_PATH="path/to/crds_cache"
+    export CRDS_SERVER_URL="https://jwst-crds.stsci.edu"
+
+If you are starting with an empty CRDS cache, the pipeline will have to download several
+GB of reference files, so the first run will be much slower. If you are getting errors
+when the reduction pipeline is reading/writing CRDS reference files, try running the 
+reduction step serially (i.e. without the `--parallel` flag) to avoid any potential race
+conditions caused by multiple processes trying to simultaneously download the same 
+reference files.
+
+The navigation and visualisation steps use SPICE kernels to calculate the observation
+geometry. The pipeline will attempt to automatically find the SPICE kernels, but this 
+will generally only work if they are saved in `~/spice_kernels` or you are running the
+code on ALICE. Therefore, the location of these kernels can customised by setting the
+environment variable ::
+
+    export PLANETMAPPER_KERNEL_PATH="path/to/spice_kernels"
+
+For more information on downloading and saving the SPICE kernels, see 
+https://planetmapper.readthedocs.io/en/latest/spice_kernels.html.
+
+
+Usage
+=====
+The pipeline can be run from the command line, or imported and run from Python. To run
+the pipeline to fully reduce a dataset, simply download the stage0 (e.g. to 
+`/data/saturn/SATURN-15N/stage0`), then run the following command on the command line ::
+
+    python3 miri_pipeline.py /data/saturn/SATURN-15N
+
+or from Python ::
+
+    import miri_pipeline
+    miri_pipeline.run_pipeline('/data/saturn/SATURN-15N')
+
+This will run the full pipeline, and output data files appropriate directories (e.g. 
+`/data/saturn/SATURN-15N/stage3`, `/data/saturn/SATURN-15N/plots` etc.).
+
+By default, the full pipeline is effectively run twice, first with the redisdual 
+defringe step disabled, then with it enabled. If you only want defringed or 
+non-defringed data, you can customise this behaviour with the `defringe` argument or the
+`--defringe` or `--no-defringe` flags.
+
+If the pipeline is run with desaturation enabled, the pipeline flow is:
+- Firstly, multiple versions of the stage0 cubes are greated with different numbers of 
+  groups (the `remove_groups` step).
+- The `reduction` and `navigation` steps are run on e.g. the 4 group data, then the
+  3 group data, then the 2 group data, then the 1 group data.
+- The `desaturate` step is then run to combine the various group data into a single
+  desaturated dataset.
+- Subsequent pipeline steps (e.g. `plot`) are run on the desaturated data.
+
+For more command line examples, see CLI_EXAMPLES below, and for more Python examples,
+see the docstring for `run_pipeline()` below.
+
+
+Customising logging
+===================
+The the `reduction` step of the pipeline can print a large amount of information to the 
+terminal. To prevent this, you can create a `stpipe-log.cfg` file in your working 
+directory, with the following contents to redirect the output to a file named 
+`pipeline.log` (this `pipeline.log` file will be created automatically if needed, so you
+don't need to create it yourself) ::
+
+    [*]
+    handler = append:pipeline.log
+    level = WARNING
+
+See https://jwst-pipeline.readthedocs.io/en/latest/jwst/stpipe/user_logging.html for
+more details.
+
+
+Example ALICE HPC job submission script
+=======================================
+The following example job submission script will run the pipeline on ALICE, using
+multiprocessing for the `reduction` step. The chmod commands at the end change the 
+permissions on data and CRDS cache files so that any new/modified files can be accessed 
+by other users in the future.
+
+The walltime and memory requirements have been tested for the giant planet observations
+(i.e. 4 dithers, ~5 groups etc.). If your data has more dithers/groups/integrations 
+etc., you may need to increase the walltime and decrease the number of nodes (ppn).
+
+To use this script you will need to:
+- replace `py310` in the `conda activate` line to the name of your conda environment
+- replace the two references to `/data/.../SATURN-15N` with the path to your data :: 
+
+    #!/bin/bash
+    #
+    #PBS -N MIRI_Pipeline
+    #PBS -l walltime=18:00:00
+    #PBS -l vmem=80gb
+    #PBS -l nodes=1:ppn=8
+    
+    source ~/.bashrc 
+    conda activate py310 # <-- replace this with the name of your conda environment
+
+    export CRDS_PATH="/data/nemesis/jwst/crds_cache"
+    export CRDS_SERVER_URL="https://jwst-crds.stsci.edu"
+
+    # Optionally redirect the verbose `reduction` step output to the file `pipeline.log`
+    if [ -f "/data/nemesis/jwst/scripts/oliver/pipelines/stpipe-log.cfg" ]; then
+        cp -f "/data/nemesis/jwst/scripts/oliver/pipelines/stpipe-log.cfg" .
+        echo "Copied stpipe-log.cfg to current working directory"
+    fi
+
+    # Run the pipeline
+    python3 /data/nemesis/jwst/scripts/oliver/pipelines/miri_pipeline.py /data/nemesis/jwst/MIRI_IFU/Saturn_2022nov13/SATURN-15N --parallel
+    
+    # Change permissions on modified files so that other users can use them
+    chmod -R --quiet 777 /data/nemesis/jwst/MIRI_IFU/Saturn_2022nov13/SATURN-15N
+    chmod -R --quiet 777 $CRDS_PATH
+"""
+STEP_DESCRIPTIONS = """
+- `remove_groups`: Remove groups from the data (for use in desaturating the data) [optional].
+- `reduction`: Run the standard JWST reduction pipeline (stage0 to stage3).
+- `navigate`: Navigate reduced files.
+- `desaturate`: Desaturate data using cubes with fewer groups [optional].
+- `flat`: Correct flat effects using synthetic flat field cubes.
+- `despike`: Clean cubes by removing extreme outlier pixels.
+- `background`: Subtract background from cubes [optional].
+- `plot`: Generate quick look summary plots of data.
+- `animate`: Generate summary animations of data.
+"""
+CLI_EXAMPLES = """examples:
+
+# Print a help message, including documentation for each argument
+python3 miri_pipeline.py -h
+
+# Run the full pipeline, with all steps enabled
+python3 miri_pipeline.py /data/saturn/SATURN-15N
+
+# Run the full pipeline, without any desaturation
+python3 miri_pipeline.py /data/saturn/SATURN-15N --no-desaturate
+
+# Run the full pipeline, with only the defringed data
+python3 miri_pipeline.py /data/saturn/SATURN-15N --defringe
+
+# Run the pipeline, including background subtraction
+python3 miri_pipeline.py /data/saturn/SATURN-15N --background_path /data/saturn/SATURN-BACKGROUND
+
+# Run the pipeline, but stop before creating any visualisations
+python3 miri_pipeline.py /data/saturn/SATURN-15N --end_step despike
+
+# Only run the plotting step
+python3 miri_pipeline.py /data/saturn/SATURN-15N --start_step plot --end_step plot
+
+# Re-run the pipeline, skipping the initial reduction steps
+python3 miri_pipeline.py /data/saturn/SATURN-15N --start_step desaturate
+
+# Run the pipeline, passing custom arguments to different steps
+python3 miri_pipeline.py /data/saturn/SATURN-RINGS --kwargs '{"reduction": {"stages": [2, 3]}, "animation": {"radius_factor": 2.5}}'
+"""
+import argparse
+import glob
+import json
+import os
+from typing import Any, Literal, TypeAlias
+
+import tqdm
+
+import background_subtraction
+import desaturate_data
+import despike_data
+import flat_field
+import jwst_summary_animation
+import jwst_summary_plots
+import navigate_jwst_observations
+import reduce_jwst_miri
+import remove_groups
+from parallel_tools import runmany
+from tools import KeepMissingDict, all_combinations, log
+
+# Central record of the filepaths for various steps of the reduction pipeline
+PATH_FITS = os.path.join(
+    '{stage}',
+    'd{dither}{fringe}{nav}',
+    'Level3_ch{channel}-{band}_s3d{nav}.fits',
+)
+PATH_PLOT = os.path.join(
+    'plots',
+    '{stage}',
+    'd{dither}{fringe}',
+    '{channel}{abc}-Level3_ch{channel}-{band}_s3d.png',
+)
+PATH_ANIMATION = os.path.join(
+    'animation',
+    '{stage}',
+    'dither_comparison{fringe}',
+    '{channel}{abc}_animation.mp4',
+)
+PATH_STAGE3_RAW = PATH_FITS.format_map(KeepMissingDict(stage='stage3', nav=''))
+PATH_DATA = PATH_FITS.format_map(KeepMissingDict(nav='_nav'))
+PATH_NAVIGATED = PATH_DATA.format_map(KeepMissingDict(stage='stage3'))
+PATH_DESATURATED = PATH_DATA.format_map(KeepMissingDict(stage='stage3_desaturated'))
+PATH_FLAT = PATH_DATA.format_map(KeepMissingDict(stage='stage4_flat'))
+PATH_DESPIKED = PATH_DATA.format_map(KeepMissingDict(stage='stage5_despike'))
+PATH_BACKGROUND = PATH_DATA.format_map(KeepMissingDict(stage='stage6_background'))
+
+DATA_STAGES = [
+    'stage3',
+    'stage3_desaturated',
+    'stage4_flat',
+    'stage5_despike',
+    'stage6_background',
+]
+
+# Get a useful default flat data path that works natively on Leicester's ALICE HPC
+_saturn_flat_path = os.path.join(
+    'MIRI_IFU/Saturn_2022nov13/flat_field/merged',
+    'ch{channel}-{band}_constructed_flat{fringe}.fits',
+)
+_path_options = [
+    os.path.join('/data/nemesis/jwst', _saturn_flat_path),
+    os.path.join(os.path.dirname(__file__), '..', 'jwst_data', _saturn_flat_path),
+    os.path.join(os.path.dirname(__file__), 'flat_field'),
+]
+DEFAULT_FLAT_DATA_PATH = _path_options[-1]
+for _p in _path_options:
+    if os.path.exists(os.path.dirname(_p)):
+        DEFAULT_FLAT_DATA_PATH = os.path.normpath(_p)
+        break
+
+# Arguments to format the paths above
+CHANNELS = ['1', '2', '3', '4']
+BANDS = ['short', 'medium', 'long']
+FRINGES = ['', '_fringe']
+CHANNEL_LENGTH_ALIASES = {'short': 'A', 'medium': 'B', 'long': 'C'}
+
+# Pipeline constants
+Step: TypeAlias = Literal[
+    'remove_groups',
+    'reduce',
+    'navigate',
+    'desaturate',
+    'flat',
+    'despike',
+    'background',
+    'plot',
+    'animate',
+]
+STEPS: list[Step] = [
+    'remove_groups',
+    'reduce',
+    'navigate',
+    'desaturate',
+    'flat',
+    'despike',
+    'background',
+    'plot',
+    'animate',
+]
+
+
+def run_pipeline(
+    root_path: str,
+    *,
+    defringe: bool | Literal['both'] = 'both',
+    desaturate: bool = True,
+    groups_to_use: list[int] | None = None,
+    background_path: str | None = None,
+    ndither: int = 4,
+    parallel: float | bool = False,
+    flat_data_path: str = DEFAULT_FLAT_DATA_PATH,
+    basic_navigation: bool = False,
+    skip_steps: list[Step] | set[Step] | None = None,
+    start_step: Step | None = None,
+    end_step: Step | None = None,
+    reduction_kwargs: dict[str, Any] | None = None,
+    navigation_kwargs: dict[str, Any] | None = None,
+    desaturation_kwargs: dict[str, Any] | None = None,
+    flat_kwargs: dict[str, Any] | None = None,
+    despike_kwargs: dict[str, Any] | None = None,
+    background_kwargs: dict[str, Any] | None = None,
+    plot_kwargs: dict[str, Any] | None = None,
+    animation_kwargs: dict[str, Any] | None = None,
+) -> None:
+    """
+    Run the full MIRI MRS reduction pipeline, including the standard reduction from
+    stage0 to stage3, and custom pipeline steps for additional cleaning and data
+    visualisation.
+
+    Examples ::
+
+        from miri_pipeline import run_pipeline
+
+        # Run the full pipeline, with all steps enabled
+        run_pipeline('/data/saturn/SATURN-15N')
+
+        # Run the full pipeline, without any desaturation
+        run_pipeline('/data/saturn/SATURN-15N', desaturate=False)
+
+        # Run the pipeline, including background subtraction
+        run_pipeline(
+            '/data/saturn/SATURN-15N',
+            background_path='data/saturn/SATURN-BACKGROUND',
+        )
+
+        # Run the pipeline, but stop before creating any visualisations
+        run_pipeline('/data/saturn/SATURN-15N', end_step='despike')
+
+        # Re-run the pipeline, skipping the initial reduction steps
+        run_pipeline('/data/saturn/SATURN-15N', start_step='desaturate')
+
+        # Run the pipeline, passing custom arguments to different steps
+        run_pipeline(
+            '/data/saturn/SATURN-RINGS',
+            reduction_kwargs={'stages': [2, 3]},
+            animation_kwargs={'radius_factor': 2.5},
+        )
+
+    Args:
+        root_path: Path to the root directory containing the data. This directory should
+            contain a subdirectory with the stage 0 data (i.e. `root_path/stage0`).
+            Additional directories will be created automatically for each step of the
+            pipeline (e.g. `root_path/stage1`, `root_path/plots` etc.).
+        defringe: Toggle defringing of the data. If True, defringe data will be saved
+            and processed. If `'both'` (the default), the pipeline will be run twice,
+            first without defringing, then again with defringing enabled. Defringed data
+            will be saved in separate directories (e.g. `root_path/stage3/d1_fringe`),
+            so both sets of data will be available for further analysis.
+        desaturate: Toggle desaturation of the data. If True, the `reduction` step will
+            be run for different numbers of groups, which are then combined in the
+            `desaturate` step to produce a desaturated data cube. If False, the
+            `reduction` step will be run only once, with the full number of groups, and
+            the `desaturate` step will be skipped (i.e. going straight to the flat field
+            step).
+        groups_to_use: List of groups to reduce and use for desaturating the data. If
+            this is `None` (the default), then all available groups will be used. If
+            `desaturate` is False, then this argument will be ignored. The data with all
+            groups will always be included.
+        background_path: Path to directory containing background data. For example, if
+            your `root_path` is `/data/saturn/SATURN-15N`, the `background_path` may
+            be `/data/saturn/SATURN-BACKGROUND`. Note that background subtraction will
+            require the background data to be already reduced. If no `background_path`
+            is specified (the default), then no background subtraction will be
+            performed.
+        ndither: Number of dithers for each observation. Defaults to 4.
+        parallel: Fraction of CPU cores to use when multiprocessing. Set to 0 to run
+            serially, 1 to use all cores, 0.5 to use half of the cores, etc. If enabled,
+            multiprocessing is used in the `reduction`, `despike`, `plot` and `animate`
+            steps.
+        flat_data_path: Optionally specify custom path to the flat field data. This path
+            should contain `{channel}`, `{band}` and `{fringe}` placeholders, which will
+            be replaced by appropriate values for each channel, band and defringe
+            setting.
+        basic_navigation: Toggle between basic or full navigation. If True, then only
+            RA and Dec navigation backplanes are generated (e.g. useful for small
+            bodies). If False (the default), then full navigation is performed,
+            generating a full set of coordinate backplanes (lon/lat, illumination
+            angles etc.). Using basic navigation automatically skips the animation step.
+        skip_steps: List of steps to skip. Defaults to None. See `STEPS` above for a
+            list of valid steps. This is mainly useful if you are re-running part of the
+            pipeline.
+        start_step: Convenience argument to add all steps before `start_step` to
+            `skip_steps`.
+        end_step: Convenience argument to add all steps after `end_step` to
+            `skip_steps`.
+
+        reduction_kwargs, navigation_kwargs, desaturation_kwargs, flat_kwargs,
+        despike_kwargs, spx_kwargs, plot_kwargs, animation_kwargs: Arguments are passed
+            to the corresponding functions for each step of the pipeline. These can
+            therefore be used to override the default values for each step. See the
+            documentation for each function for details on the arguments.
+    """
+    if skip_steps is None:
+        skip_steps = []
+    for s in skip_steps:
+        if s not in STEPS:
+            raise ValueError(f'Invalid skip step: {s!r} (valid steps: {STEPS})')
+    skip_steps = set(skip_steps)
+    if start_step is not None:
+        if start_step not in STEPS:
+            raise ValueError(
+                f'Invalid start step: {start_step!r} (valid steps: {STEPS})'
+            )
+        skip_steps.update(STEPS[: STEPS.index(start_step)])
+    if end_step is not None:
+        if end_step not in STEPS:
+            raise ValueError(f'Invalid end step: {end_step!r} (valid steps: {STEPS})')
+        skip_steps.update(STEPS[STEPS.index(end_step) + 1 :])
+
+    if basic_navigation:
+        skip_steps.add('animate')
+
+    # Standardise file paths
+    root_path = os.path.expandvars(os.path.expanduser(root_path))
+    if background_path is not None:
+        background_path = os.path.expandvars(os.path.expanduser(background_path))
+    flat_data_path = os.path.expandvars(os.path.expanduser(flat_data_path))
+
+    log('Running MIRI pipeline')
+    log(f'Root path: {root_path!r}', time=False)
+    if skip_steps:
+        log(
+            f'Skipping steps: {", ".join([repr(s) for s in STEPS if s in skip_steps])}',
+            time=False,
+        )
+    else:
+        log('Running all pipeline steps', time=False)
+    log(f'Defringe: {defringe!r}', time=False)
+    log(f'Desaturate: {desaturate!r}', time=False)
+    if groups_to_use:
+        log(f'Groups to keep: {groups_to_use!r}', time=False)
+    if basic_navigation:
+        log(f'Basic navigation: {basic_navigation!r}', time=False)
+    log(f'Number of dithers: {ndither!r}', time=False)
+    print()
+
+    if defringe == 'both':
+        kwargs = dict(
+            desaturate=desaturate,
+            groups_to_use=groups_to_use,
+            background_path=background_path,
+            ndither=ndither,
+            parallel=parallel,
+            flat_data_path=flat_data_path,
+            basic_navigation=basic_navigation,
+            navigation_kwargs=navigation_kwargs,
+            desaturation_kwargs=desaturation_kwargs,
+            flat_kwargs=flat_kwargs,
+            despike_kwargs=despike_kwargs,
+            background_kwargs=background_kwargs,
+            plot_kwargs=plot_kwargs,
+            animation_kwargs=animation_kwargs,
+        )
+
+        # First, run the entire pipeline with defringe=False
+        # (do defringe=False first as it is much faster)
+        run_pipeline(
+            root_path,
+            defringe=False,
+            skip_steps=skip_steps,
+            reduction_kwargs=reduction_kwargs,
+            **kwargs,
+        )
+
+        # Then run the pipeline from the defringe step onwards with defringe=True
+        # (no need to run the remove groups and reduction stages 1&2 again)
+        skip_steps |= {'remove_groups'}
+        reduction_kwargs = reduction_kwargs or {}
+        reduction_kwargs.setdefault('stages', [2.5, 3])
+        run_pipeline(
+            root_path,
+            defringe=True,
+            skip_steps=skip_steps,
+            reduction_kwargs=reduction_kwargs,
+            **kwargs,
+        )
+
+        log('MIRI pipeline completed for both defringe settings')
+        print()
+        return
+
+    # Run pipeline steps...
+
+    if desaturate and 'remove_groups' not in skip_steps:
+        log('Removing groups from data...')
+        files = sorted(glob.glob(os.path.join(root_path, 'stage0', '*.fits')))
+        # Allow customisation of remove_groups() groups_to_use argument with kwargs
+        kw = {**dict(groups_to_use=groups_to_use), **(desaturation_kwargs or {})}
+        for _p in tqdm.tqdm(files, desc='Removing groups'):
+            remove_groups.remove_groups_from_file(_p, **kw)
+        log('Remove groups step complete\n')
+
+    # Create list of paths to reduce (both 'main' dataset and reduced groups)
+    group_root_paths = [root_path]
+    if desaturate:
+        # If desaturating, we also need to reduce the data with fewer groups
+        # This list is sorted such that the number of groups is decreasing (so that the
+        # desaturation works correctly)
+        reduced_group_root_paths = sorted(
+            glob.glob(os.path.join(root_path, 'groups', '*_groups')),
+            reverse=True,
+            key=lambda _p: int(os.path.basename(_p).split('_')[0]),
+        )
+        if groups_to_use is not None:
+            reduced_group_root_paths = [
+                _p
+                for _p in reduced_group_root_paths
+                if int(os.path.basename(_p).split('_')[0]) in groups_to_use
+            ]
+        group_root_paths.extend(reduced_group_root_paths)
+
+    if 'reduce' not in skip_steps:
+        log('Reducing data...')
+        for _p in group_root_paths:
+            # Allow customisation of reduction parallel kw with reduction_kwargs
+            kw = {**dict(parallel=parallel), **(reduction_kwargs or {})}
+            reduce_jwst_miri.JWSTReduction(
+                _p,
+                defringe=defringe,
+                _run_immediately=True,
+                **kw,
+            )
+        log('Reduction step complete\n')
+
+    if 'navigate' not in skip_steps:
+        log('Navigating data...')
+        paths_to_navigate = []
+        for _p in group_root_paths:
+            paths_to_navigate.extend(
+                get_stage_paths(_p, PATH_STAGE3_RAW, defringe, ndither)
+            )
+        paths_to_navigate = [_p for _p in paths_to_navigate if os.path.exists(_p)]
+        navigate_jwst_observations.load_kernels()
+        navigate_jwst_observations.navigate_multiple(
+            *paths_to_navigate, basic=basic_navigation, **navigation_kwargs or {}
+        )
+        log('Navigation step complete\n')
+
+    if desaturate and 'desaturate' not in skip_steps:
+        log('Desaturating data...')
+        paths_in_list = [
+            get_stage_paths(_p, PATH_NAVIGATED, defringe, ndither)
+            for _p in group_root_paths
+        ]
+        paths_out = get_stage_paths(root_path, PATH_DESATURATED, defringe, ndither)
+        args_list = []
+        for paths_in, path_out in zip(zip(*paths_in_list), paths_out):
+            if os.path.exists(paths_in[0]):
+                args_list.append((paths_in, path_out))
+
+        log(f'Processing {len(args_list)} files...')
+        for paths_in, paths_out in tqdm.tqdm(args_list, desc='Desaturating'):
+            desaturate_data.replace_saturated(
+                paths_in, paths_out, **desaturation_kwargs or {}
+            )
+        log('Desaturation step complete\n')
+
+    if 'flat' not in skip_steps:
+        log('Applying flat fields...')
+        pattern_in = PATH_DESATURATED if desaturate else PATH_NAVIGATED
+        log(f'Input file pattern: {pattern_in!r}', time=False)
+        log(f'Flat data path: {flat_data_path!r}', time=False)
+        paths = [
+            (p_in, p_out, p_flat)
+            for p_in, p_out, p_flat in zip(
+                get_stage_paths(root_path, pattern_in, defringe, ndither),
+                get_stage_paths(root_path, PATH_FLAT, defringe, ndither),
+                get_stage_paths(None, flat_data_path, defringe, ndither),
+            )
+            if os.path.exists(p_in)
+        ]
+
+        log(f'Processing {len(paths)} files...')
+        for p_in, p_out, p_flat in tqdm.tqdm(paths, desc='Flat fielding'):
+            flat_field.apply_flat(p_in, p_out, p_flat, **flat_kwargs or {})
+        log('Flat fielding step complete\n')
+
+    if 'despike' not in skip_steps:
+        log('Despiking data...')
+        paths = [
+            (p_in, p_out)
+            for p_in, p_out in zip(
+                get_stage_paths(root_path, PATH_FLAT, defringe, ndither),
+                get_stage_paths(root_path, PATH_DESPIKED, defringe, ndither),
+            )
+            if os.path.exists(p_in)
+        ]
+
+        log(f'Processing {len(paths)} files...')
+        if parallel:
+            despike_kwargs = despike_kwargs or {}
+            despike_kwargs['progress_bar'] = False
+        despike_args = [(p_in, p_out, despike_kwargs) for p_in, p_out in paths]
+        runmany(despike_fn, despike_args, parallel_frac=parallel, desc='Despiking')
+        log('Despiking step complete\n')
+
+    if (background_path is not None) and ('background' not in skip_steps):
+        log('Subtracting background...')
+        log(f'Background path: {background_path!r}', time=False)
+        paths = [
+            (p_in, p_out, p_bg)
+            for p_in, p_out, p_bg in zip(
+                get_stage_paths(root_path, PATH_DESPIKED, defringe, ndither),
+                get_stage_paths(root_path, PATH_BACKGROUND, defringe, ndither),
+                get_stage_paths(
+                    background_path,
+                    PATH_DESPIKED.format_map(KeepMissingDict(dither='1')),
+                    defringe,
+                    ndither,
+                ),
+            )
+            if os.path.exists(p_in) and os.path.exists(p_bg)
+        ]
+        log(f'Processing {len(paths)} files...')
+        for p_in, p_out, p_bg in tqdm.tqdm(paths, desc='Background subtracting'):
+            background_subtraction.subtract_background(
+                p_in, p_out, p_bg, **flat_kwargs or {}
+            )
+        log('Background step complete\n')
+
+    if 'plot' not in skip_steps:
+        log('Generating quick look plots...')
+        # Reverse stages so that we get plots of the 'final' version generated first
+        for stage in reversed(DATA_STAGES):
+            log(f'Generating plots for stage {stage}...')
+            template_in = PATH_DATA.format_map(KeepMissingDict(stage=stage))
+            template_out = PATH_PLOT.format_map(KeepMissingDict(stage=stage))
+            paths = []
+            for _p in group_root_paths:
+                paths.extend(
+                    [
+                        (p_in, p_out)
+                        for p_in, p_out in zip(
+                            get_stage_paths(_p, template_in, defringe, ndither),
+                            get_stage_paths(_p, template_out, defringe, ndither),
+                        )
+                        if os.path.exists(p_in)
+                    ]
+                )
+
+            log(f'Processing {len(paths)} files...')
+            plot_args = [(p_in, p_out, plot_kwargs) for p_in, p_out in paths]
+            runmany(
+                plot_fn, plot_args, parallel_frac=parallel, desc=f'Plotting {stage}'
+            )
+
+        log('Plotting step complete\n')
+
+    if 'animate' not in skip_steps:
+        log('Generating animations...')
+        # Use dict for paths here as multiple input paths map to the same output
+        paths_dict: dict[str, list[str]] = {}
+        for stage in reversed(DATA_STAGES):
+            template_in = PATH_DATA.format_map(KeepMissingDict(stage=stage))
+            template_out = PATH_ANIMATION.format_map(KeepMissingDict(stage=stage))
+            for p_in, p_out in zip(
+                get_stage_paths(root_path, template_in, defringe, ndither),
+                get_stage_paths(root_path, template_out, defringe, ndither),
+            ):
+                if os.path.exists(p_in):
+                    paths_dict.setdefault(p_out, []).append(p_in)
+
+        log(f'{len(paths_dict)} animations to process...')
+        animation_kwargs = animation_kwargs or {}
+        animation_kwargs.setdefault('print_output', False)
+        if parallel:
+            animation_kwargs.setdefault('progress_bar', False)
+        animation_args = [
+            (p_out, p_ins, animation_kwargs) for p_out, p_ins in paths_dict.items()
+        ]
+        runmany(
+            animation_fn,
+            animation_args,
+            parallel_frac=parallel,
+            desc='Animating',
+        )
+        log('Animation step complete\n')
+
+    log('MIRI pipeline complete')
+    log(f'Root path: {root_path!r}', time=False)
+    log(f'Defringe: {defringe!r}', time=False)
+    log(f'Desaturate: {desaturate!r}', time=False)
+    if skip_steps:
+        log(
+            f'Skipped steps: {", ".join([repr(s) for s in STEPS if s in skip_steps])}',
+            time=False,
+        )
+    print()
+
+
+def despike_fn(args: tuple[str, str, dict[str, Any] | None]):
+    p_in, p_out, despike_kwargs = args
+    despike_data.despike_cube(p_in, p_out, **despike_kwargs or {})
+
+
+def plot_fn(args: tuple[str, str, dict[str, Any] | None]):
+    p_in, p_out, plot_kwargs = args
+    jwst_summary_plots.make_summary_plot(p_in, p_out, **plot_kwargs or {})
+
+
+def animation_fn(args: tuple[str, list[str], dict[str, Any] | None]):
+    p_out, p_ins, animation_kwargs = args
+    jwst_summary_animation.make_animation(p_ins, p_out, **animation_kwargs or {})
+
+
+def get_stage_paths(
+    root_path: str | None,
+    template: str,
+    defringe: bool,
+    ndither: int,
+) -> list[str]:
+    """
+    Get a list of paths for all combinations of dithers, channels and bands for a given
+    stage of the reduction.
+
+    Args:
+        root_path: Directory containing the data.
+        template: Path of the data files relative to the `root_path`. The values
+            `{dither}`, `{channel}`, `{band}`, `{abc}` and `{fringe}` will be replaced
+            with the corresponding values for each individual file.
+        defringe: Toggle defringing.
+        ndither: Number of dithers.
+
+    Returns:
+        List of file paths, constructed from the root path and the template.
+    """
+    if root_path:
+        template = os.path.join(root_path, template)
+    fringe = '_fringe' if defringe else ''
+    dithers = [str(i + 1) for i in range(ndither)]
+
+    paths = []
+    for path_kw in all_combinations(
+        dither=dithers,
+        channel=CHANNELS,
+        band=BANDS,
+    ):
+        path_kw['abc'] = CHANNEL_LENGTH_ALIASES[path_kw['band']]
+        paths.append(template.format(fringe=fringe, **path_kw))
+    return paths
+
+
+def main():
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(
+        description=(
+            'Full JWST MIRI pipeline including the standard reduction from stage0 to '
+            'stage3, and custom pipeline steps for additional cleaning and data '
+            'visualisation. For more customisation, this script can be imported and '
+            'run in Python (see the source code for mode details).\n\n'
+            'The following steps are run in the full pipeline:' + STEP_DESCRIPTIONS
+        ),
+        epilog=CLI_EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        argument_default=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        'root_path',
+        type=str,
+        help="""Path to the directory containing the data. This directory should
+            contain a subdirectory with the stage0 data (i.e. `root_path/stage0`).
+            Additional directories will be created automatically for each step of the
+            pipeline (e.g. `root_path/stage1`, `root_path/plots` etc.).""",
+    )
+    parser.add_argument(
+        '--defringe',
+        action=argparse.BooleanOptionalAction,
+        default='both',
+        help="""Toggle defringing of the data. If unspecified, the pipeline will be run 
+            twice, first without defringing, then again with defringing enabled.""",
+    )
+    parser.add_argument(
+        '--desaturate',
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="""Toggle desaturation of the data. If desaturation is enabled the 
+            `reduction` step will be run for different numbers of groups, which are then
+            combined in the `desaturate` step to produce a desaturated data cube. This
+            desaturation is enabled by default.
+            """,
+    )
+    parser.add_argument(
+        '--groups_to_use',
+        type=str,
+        help="""Comma-separated list of groups to keep. For example, `1,2,3,4` will
+            keep the first four groups. If unspecified, all groups will be kept.""",
+    )
+    parser.add_argument(
+        '--background_path',
+        type=str,
+        help="""Path to directory containing background data. For example, if
+            your `root_path` is `/data/saturn/SATURN-15N`, the `background_path` may
+            be `/data/saturn/SATURN-BACKGROUND`. Note that background subtraction will
+            require the background data to be already reduced. If no `background_path`
+            is specified (the default), then no background subtraction will be 
+            performed.""",
+    )
+    parser.add_argument(
+        '--ndither',
+        type=int,
+        default=4,
+        help="""Number of dithers in the dataset. Defaults to 4.""",
+    )
+    parser.add_argument(
+        '--parallel',
+        nargs='?',
+        const=1,
+        type=float,
+        help="""Fraction of CPU cores to use when multiprocessing. For example, set 
+        0.5 to use half of the available cores. If unspecified, then multiprocessing 
+        will not be used and the pipeline will be run serially. If specified but no 
+        value is given, then all available cores will be used (i.e. `--parallel` is 
+        equivalent to `--parallel 1`). If enabled, multiprocessing is used in the 
+        `reduction`, `despike`, `plot` and `animate` steps.""",
+    )
+    parser.add_argument(
+        '--flat_data_path',
+        type=str,
+        help="""Optionally specify custom path to the flat field data. This path
+            should contain `{channel}`, `{band}` and `{fringe}` placeholders, which will
+            be replaced by appropriate values for each channel, band and defringe
+            setting.""",
+    )
+    parser.add_argument(
+        '--basic_navigation',
+        action='store_true',
+        help="""Use basic navigation, and only save RA and Dec backplanes (e.g. useful
+            for small bodies). By default, full navigation is performed, generating a
+            full set of coordinate backplanes (lon/lat, illumination angles etc.). Using
+            basic navigation automatically skips the navigation step.""",
+    )
+    parser.add_argument(
+        '--skip_steps',
+        nargs='+',
+        type=str,
+        help="""List of steps to skip. This is generally only useful if you are
+            re-running part of the pipeline. Multiple steps can be passed as a
+            space-separated list. For example, `--skip_steps flat despike`.""",
+    )
+    parser.add_argument(
+        '--start_step',
+        type=str,
+        help="""Convenience argument to add all steps before `start_step` to 
+            `skip_steps`.""",
+    )
+    parser.add_argument(
+        '--end_step',
+        type=str,
+        help="""Convenience argument to add all steps steps after `end_step` to 
+            `skip_steps`.""",
+    )
+    parser.add_argument(
+        '--kwargs',
+        type=str,
+        help="""JSON string containing keyword arguments to pass to individual pipeline
+            steps. For example, 
+            `--kwargs '{"reduction": {"stages": [2, 3]}, "animation": {"radius_factor": 2.5}}'` 
+            will pass the custom arguments to the reduction and animation steps.
+            """,
+    )
+    args = vars(parser.parse_args())
+    json_kwargs = args.pop('kwargs', None)
+    if json_kwargs:
+        json_kwargs = json.loads(json_kwargs)
+        for k, v in json_kwargs.items():
+            if not k.endswith('_kwargs'):
+                k = k + '_kwargs'
+            args[k] = v
+    if 'groups_to_use' in args:
+        args['groups_to_use'] = [int(g) for g in args['groups_to_use'].split(',')]
+    run_pipeline(**args)
+
+
+if __name__ == '__main__':
+    main()

--- a/navigate_jwst_observations.py
+++ b/navigate_jwst_observations.py
@@ -108,6 +108,7 @@ def navigate_file(
     ra_offset: float = RA_OFFSET,
     dec_offset: float = DEC_OFFSET,
     basic: bool = False,
+    rename_directory: bool = True,
 ) -> datetime.datetime:
     path = os.path.abspath(path)
 
@@ -162,16 +163,17 @@ def navigate_file(
             header['DATE-END'], '%Y-%m-%dT%H:%M:%S.%f'
         )
 
-        path_out = make_output_path(path)
+        path_out = make_output_path(path, rename_directory)
         check_path(path_out)
         hdul.writeto(path_out, overwrite=True)
     return date_end
 
 
-def make_output_path(path: str) -> str:
+def make_output_path(path: str, rename_directory: bool) -> str:
     directory_path, filename = os.path.split(path)
     root, directory = os.path.split(directory_path)
-    directory = directory + '_nav'
+    if rename_directory:
+        directory = directory + '_nav'
     filename = filename.replace('.fits', '_nav.fits')
     return os.path.join(root, directory, filename)
 

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -170,7 +170,7 @@ python3 nirspec_pipeline.py /data/uranus/lon1 --start_step plot --end_step plot
 python3 nirspec_pipeline.py /data/uranus/lon1 --start_step desaturate
 
 # Run the pipeline, passing custom arguments to different steps
-python3 nirspec_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "animation": {"radius_factor": 2.5}}'
+python3 nirspec_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "plot": {"plot_brightest_spectrum": true}, "animation": {"radius_factor": 2.5}}'
 """
 import argparse
 import glob
@@ -305,6 +305,7 @@ def run_pipeline(
             stage3_kwargs={
                 'outlier_detection': {'snr': '30.0 24.0', 'scale': '1.3 0.7'}
             },
+            plot_kwargs={'plot_brightest_spectrum': True},
             animation_kwargs={'radius_factor': 2.5},
         )
 

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -430,7 +430,7 @@ def run_pipeline(
         run_stage3(group_root_paths, stage3_kwargs, reduction_parallel_kwargs)
 
     if 'navigate' not in skip_steps:
-        run_navigation(group_root_paths, basic_navigation, navigate_kwargs)
+        run_navigate(group_root_paths, basic_navigation, navigate_kwargs)
 
     if desaturate and 'desaturate' not in skip_steps:
         run_desaturate(root_path, group_root_paths, desaturate_kwargs, parallel_kwargs)
@@ -664,7 +664,7 @@ def reduction_spec3_fn(args: tuple[str, str, dict[str, Any]]) -> None:
 
 
 # navigation
-def run_navigation(
+def run_navigate(
     group_root_paths: list[str],
     basic_navigation: bool = False,
     navigate_kwargs: dict[str, Any] | None = None,

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-f"""
+"""
 Full JWST reduction pipeline for NIRSpec IFU data, including the standard reduction from
 stage0 to stage3, and custom pipeline steps for additional cleaning and data 
 visualisation.
@@ -387,7 +387,7 @@ class NirspecPipeline(Pipeline):
     # Step overrides
     def reduction_spec2_fn(self, args: tuple[str, str, dict[str, Any]]) -> None:
         try:
-            return super().reduction_spec2_fn(args)
+            super().reduction_spec2_fn(args)
         except NoDataOnDetectorError:
             path_in, output_dir, kwargs = args
             print(f'No data on detector for {path_in!r}, skipping')

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
+f"""
 Full JWST reduction pipeline for NIRSpec IFU data, including the standard reduction from
 stage0 to stage3, and custom pipeline steps for additional cleaning and data 
 visualisation.
@@ -67,6 +67,21 @@ If the pipeline is run with desaturation enabled, the pipeline flow is:
 - The `desaturate` step is then run to combine the various group data into a single
   desaturated dataset.
 - Subsequent pipeline steps (e.g. `plot`) are run on the desaturated data.
+
+Data cubes are saved at each step of the pipeline, with the data in each stage directory
+used as the input for the next stage. The `stage0`, `stage1` and `stage2` directories
+contain partially reduced data cubes. The `stage3` directory onwards contain reduced 
+data cubes which can be used for science. Within each science directory (`stage3`, 
+`stage4...` etc.), files are organised by dither and any data variant. For example:
+- `stage3/d1` contains the stage3 data for dither 1
+- `stage3/d2_bg` contains the stage3 data for dither 2 with the background subtracted
+- `stage3/combined` contains the stage4 data with all dithers combined
+- `stage4_flat/d3` contains the stage4 for dither 3
+
+The `plots` and `animation` directories contain quick look visualisations of the data.
+
+Metadata about the pipeline processing steps is saved in the `PRIMARY` FITS header of 
+each file.
 
 For more command line examples, see CLI_EXAMPLES below, and for more Python examples,
 see the docstring for `run_pipeline()` below.

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -597,7 +597,7 @@ def run_stage3(
             write_asn_for_stage3(
                 paths,
                 asn_path,
-                prodname='Level3' + f'_{tile}' if include_tile_in_prodname else '',
+                prodname='Level3' + (f'_{tile}' if include_tile_in_prodname else ''),
             )
             asn_paths_list.append((asn_path, output_dir))
         args_list = [

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -59,7 +59,7 @@ This will run the full pipeline, and output data files appropriate directories (
 `/data/uranus/lon1/stage3`, `/data/uranus/lon1/plots` etc.).
 
 If the pipeline is run with desaturation enabled, the pipeline flow is:
-- Firstly, multiple versions of the stage0 cubes are greated with different numbers of 
+- Firstly, multiple versions of the stage0 cubes are created with different numbers of 
   groups (the `remove_groups` step).
 - `stage1` is run on e.g. the 4 group data, then the 3 group data, then the 2 group
   data, then the 1 group data. Then `stage2` is run on the 4-1 group data, then 

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -750,7 +750,6 @@ def despike_fn(args: tuple[str, str, dict[str, Any]]) -> None:
 # background
 def run_background(
     root_path: str,
-    defringe_options: list[bool],
     background_path: str,
     background_kwargs: dict[str, Any] | None = None,
 ) -> None:

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -393,6 +393,8 @@ def run_pipeline(
 
     # Standardise file paths
     root_path = os.path.expandvars(os.path.expanduser(root_path))
+    if background_path is not None:
+        background_path = os.path.expandvars(os.path.expanduser(background_path))
 
     # Print info
     log('Running NIRSpec pipeline')

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -131,12 +131,11 @@ To use this script you will need to:
 STEP_DESCRIPTIONS = """
 - `remove_groups`: Remove groups from the data (for use in desaturating the data) [optional].
 - `stage1`: Run the standard JWST reduction pipeline stage 1.
-- `stage2`: Run the standard JWST reduction pipeline stage 2.
+- `stage2`: Run the standard JWST reduction pipeline stage 2 (including optional background subtraction).
 - `stage3`: Run the standard JWST reduction pipeline stage 3.
 - `navigate`: Navigate reduced files.
 - `desaturate`: Desaturate data using cubes with fewer groups [optional].
 - `despike`: Clean cubes by removing extreme outlier pixels.
-- `background`: Subtract background from cubes [optional].
 - `plot`: Generate quick look summary plots of data.
 - `animate`: Generate summary animations of data.
 """
@@ -170,33 +169,16 @@ python3 nirspec_pipeline.py /data/uranus/lon1 --start_step plot --end_step plot
 python3 nirspec_pipeline.py /data/uranus/lon1 --start_step desaturate
 
 # Run the pipeline, passing custom arguments to different steps
-python3 nirspec_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "plot": {"plot_brightest_spectrum": true}, "animation": {"radius_factor": 2.5}}'
+python3 nirspec_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "plot": {"plot_brightest_spectrum": false}, "animation": {"radius_factor": 2.5}}'
 """
-import argparse
-import glob
-import json
-import os
-import pathlib
-from typing import Any, Literal, TypeAlias
+from typing import Any, Collection, Literal
 
-import tqdm
-from astropy.io import fits
 from jwst.assign_wcs.util import NoDataOnDetectorError
-from jwst.associations.asn_from_list import asn_from_list
-from jwst.associations.lib.rules_level3_base import DMS_Level3_Base
-from jwst.pipeline import Detector1Pipeline, Spec2Pipeline, Spec3Pipeline
 
-import background_subtraction
-import desaturate_data
-import despike_data
-import jwst_summary_animation
-import jwst_summary_plots
-import navigate_jwst_observations
-import remove_groups
-from parallel_tools import runmany
-from tools import check_path, log
+from pipeline import Pipeline, Step, get_pipeline_argument_parser
 
-Step: TypeAlias = Literal[
+# Pipeline constants for NIRSpec
+STEPS: tuple[Step, ...] = (
     'remove_groups',
     'stage1',
     'stage2',
@@ -204,68 +186,46 @@ Step: TypeAlias = Literal[
     'navigate',
     'desaturate',
     'despike',
-    'background',
     'plot',
     'animate',
-]
-STEPS: list[Step] = [
-    'remove_groups',
-    'stage1',
-    'stage2',
-    'stage3',
-    'navigate',
-    'desaturate',
-    'despike',
-    'background',
-    'plot',
-    'animate',
-]
-
-DATA_STAGES = [
+)
+DEFAULT_KWARGS: dict[Step, dict[str, Any]] = {
+    'stage2': {
+        'steps': {
+            'cube_build': {'skip': True},
+            'extract_1d': {'skip': True},
+            'bkg_subtract': {'skip': False},
+        }
+    },
+    'stage3': {
+        'steps': {
+            'extract_1d': {'skip': True},
+            'cube_build': {'coord_system': 'ifualign'},
+        }
+    },
+}
+STEP_DIRECTORIES: dict[Step, tuple[str, str]] = {'despike': ('', 'stage4_despike')}
+STAGE_DIRECTORIES_TO_PLOT = (
     'stage3',
     'stage3_desaturated',
     'stage4_despike',
     'stage5_background',
-]
-
-# Default arguments for each step. These are merged with the user-supplied kwargs
-# before being passed to the pipeline, for example:
-# stage1_kwargs = DEFAULT_STAGE1_KWARGS | stage1_kwargs
-DEFAULT_STAGE1_KWARGS = {}
-DEFAULT_STAGE2_KWARGS = {
-    'steps': {'cube_build': {'coord_system': 'ifualign'}, 'extract_1d': {'skip': True}}
-}
-DEFAULT_STAGE3_KWARGS = {
-    'steps': {'cube_build': {'coord_system': 'ifualign'}, 'extract_1d': {'skip': True}}
-}
-DEFAULT_DESATURATE_KWARGS = {}
-DEFAULT_NAVIGATE_KWARGS = {}
-DEFAULT_DESPIKE_KWARGS = {}
-DEFAULT_BACKGROUND_KWARGS = {}
-DEFAULT_PLOT_KWARGS = {}
-DEFAULT_ANIMATE_KWARGS = {}
+)
 
 
 def run_pipeline(
     root_path: str,
     *,
-    desaturate: bool = True,
-    groups_to_use: list[int] | None = None,
-    background_path: str | None = None,
-    parallel: float | bool = False,
-    basic_navigation: bool = False,
-    skip_steps: list[Step] | set[Step] | None = None,
+    skip_steps: Collection[Step] | None = None,
     start_step: Step | None = None,
     end_step: Step | None = None,
-    stage1_kwargs: dict[str, Any] | None = None,
-    stage2_kwargs: dict[str, Any] | None = None,
-    stage3_kwargs: dict[str, Any] | None = None,
-    desaturate_kwargs: dict[str, Any] | None = None,
-    navigate_kwargs: dict[str, Any] | None = None,
-    despike_kwargs: dict[str, Any] | None = None,
-    background_kwargs: dict[str, Any] | None = None,
-    plot_kwargs: dict[str, Any] | None = None,
-    animate_kwargs: dict[str, Any] | None = None,
+    parallel: float | bool = False,
+    desaturate: bool = True,
+    groups_to_use: list[int] | None = None,
+    background_subtract: bool | Literal['both'] = 'both',
+    background_path: str | None = None,
+    basic_navigation: bool = False,
+    step_kwargs: dict[Step, dict[str, Any]] | None = None,
     parallel_kwargs: dict[str, Any] | None = None,
     reduction_parallel_kwargs: dict[str, Any] | None = None,
 ) -> None:
@@ -287,7 +247,7 @@ def run_pipeline(
         # Run the full pipeline, without any desaturation
         run_pipeline('/data/uranus/lon1', desaturate=False)
 
-        # Run the pipeline, including background subtraction
+        # Run the pipeline, including background subtraction in stage2
         run_pipeline(
             '/data/uranus/lon1',
             background_path='data/uranus/background',
@@ -302,714 +262,127 @@ def run_pipeline(
         # Run the pipeline, passing custom arguments to different steps
         run_pipeline(
             '/data/uranus/lon1',
-            stage3_kwargs={
-                'outlier_detection': {'snr': '30.0 24.0', 'scale': '1.3 0.7'}
+            kwargs{
+                'stage3: {
+                    'outlier_detection': {'snr': '30.0 24.0', 'scale': '1.3 0.7'}
+                },
+                'plot': {'plot_brightest_spectrum': False},
+                'animate': {'radius_factor': 2.5},
             },
-            plot_kwargs={'plot_brightest_spectrum': True},
-            animation_kwargs={'radius_factor': 2.5},
         )
 
     Args:
         root_path: Path to the root directory containing the data. This directory should
             contain a subdirectory with the stage 0 data (i.e. `root_path/stage0`).
             Additional directories will be created automatically for each step of the
-            pipeline (e.g. `root_path/stage1`, `root_path/plots` etc.).
-        desaturate: Toggle desaturation of the data. If True, the `stage1` to `navigate`
-            steps will be run for different numbers of groups, which are then combined
-            in the `desaturate` step to produce a desaturated data cube. If False, the
-            `reduction` step will be run only once, with the full number of groups, and
-            the `desaturate` step will be skipped (i.e. going straight to the despike
-            step).
-        parallel: Fraction of CPU cores to use when multiprocessing. Set to 0 to run
-            serially, 1 to use all cores, 0.5 to use half of the cores, etc.
-        groups_to_use: List of groups to reduce and use for desaturating the data. If
-            this is `None` (the default), then all available groups will be used. If
-            `desaturate` is False, then this argument will be ignored. The data with all
-            groups will always be included.
-        background_path: Path to directory containing background data. For example, if
-            your `root_path` is `/data/uranus/lon1`, the `background_path` may
-            be `/data/uranus/background`. Note that background subtraction will
-            require the background data to be already reduced. If no `background_path`
-            is specified (the default), then no background subtraction will be
-            performed.
-        basic_navigation: Toggle between basic or full navigation. If True, then only
-            RA and Dec navigation backplanes are generated (e.g. useful for small
-            bodies). If False (the default), then full navigation is performed,
-            generating a full set of coordinate backplanes (lon/lat, illumination
-            angles etc.). Using basic navigation automatically skips the animation step.
-        skip_steps: List of steps to skip. Defaults to None. See `STEPS` above for a
-            list of valid steps. This is mainly useful if you are re-running part of the
-            pipeline.
+            pipeline (e.g. `root_path/stage1`, `root_path/plots` etc.). This is the only
+            required argument.
+
+        skip_steps: List of steps to skip.
         start_step: Convenience argument to add all steps before `start_step` to
             `skip_steps`.
         end_step: Convenience argument to add all steps after `end_step` to
             `skip_steps`.
 
-        stage1_kwargs, stage2_kwargs, stage3_kwargs, desaturate_kwargs,
-        navigate_kwargs, despike_kwargs, background_kwargs, plot_kwargs, animate_kwargs:
-            Dictionaries of arguments passed to the corresponding functions for each
-            step of the pipeline. These can therefore be used to override the default
-            values for each step. See the documentation for each function for details on
-            the arguments. See the constants (e.g. DEFAULT_STAGE1_KWARGS) above for the
-            default values.
+        parallel: Fraction of CPU cores to use when multiprocessing. Set to 0 to run
+            serially, 1 to use all cores, 0.5 to use half of the cores, etc.
+        desaturate: Toggle desaturation of the data. If True, the `stage1`-`navigate`
+            steps will be run for different numbers of groups, which are then combined
+            in the`desaturate` step to produce a desaturated data cube.
+        groups_to_use: List of groups to reduce and use for desaturating the data. If
+            this is `None` (the default), then all available groups will be used. If
+            `desaturate` is False, then this argument will be ignored. The data with all
+            groups will always be included.
+        background_subtract: Toggle background subtraction. If True, the backgrounds
+            in the `background_path` directory will be subtracted from the data in
+            `stage2`. If 'both' (the default), then versions with and without background
+            subtraction will be created.
+        background_path: Path to the directory containing the background data (i.e. the
+            equivalent of `root_path` for the background observations). Note that the
+            background data must be reduced to at least `stage1` for this to work as
+            the *_rate.fits files are used for the background subtraction.
+        basic_navigation: Toggle between basic or full navigation. If True, then only
+            RA and Dec navigation backplanes are generated (e.g. useful for small
+            bodies). If False (the default), then full navigation is performed,
+            generating a full set of coordinate backplanes (lon/lat, illumination
+            angles etc.). Using basic navigation automatically skips the animation step.
+            This is mainly useful if you get SPICE errors when navigating the data.
+        step_kwargs: Dictionary of keyword arguments to pass to each step of the
+            pipeline. The keys should be the step names (e.g. `stage1`, `stage2` etc.)
+            and the values should be dictionaries of keyword arguments to pass to the
+            step. See the documentation for each step for the available keyword
+            arguments. For example,
+            `step_kwargs={'stage3':{'outlier_detection': {'snr': '30.0 24.0', 'scale': '1.3 0.7'}}}`
+            can will customise the `stage3` step. See the DEFAULT_KWARGS constant above
+            for the default values.
+        parallel_kwargs: Dictionary of keyword arguments to customise parallel
+            processing.
+        reduction_parallel_kwargs: Dictionary of keyword arguments to customise parallel
+            processing for the reduction steps (i.e. `stage1`-`stage3`). This will be
+            merged with `parallel_kwargs` (i.e.
+            `parallel_kwargs | reduction_parallel_kwargs
     """
-    # Process args
-    parallel_kwargs = dict(
-        parallel_frac=parallel,
-        timeout=60 * 60,
-    ) | (parallel_kwargs or {})
-    reduction_parallel_kwargs = (
-        parallel_kwargs
-        | dict(
-            start_delay=10,
-            parallel_job_kw=dict(
-                caught_error_wait_time=15,
-                caught_error_wait_time_frac=1,
-                caught_error_wait_time_max=600,
-            ),
-        )
-        | (reduction_parallel_kwargs or {})
+    pipeline = NirspecPipeline(
+        root_path,
+        parallel=parallel,
+        desaturate=desaturate,
+        groups_to_use=groups_to_use,
+        background_subtract=background_subtract,
+        background_path=background_path,
+        basic_navigation=basic_navigation,
+        step_kwargs=step_kwargs,
+        parallel_kwargs=parallel_kwargs,
+        reduction_parallel_kwargs=reduction_parallel_kwargs,
     )
-
-    # Process skip steps
-    if skip_steps is None:
-        skip_steps = []
-    for s in skip_steps:
-        if s not in STEPS:
-            raise ValueError(f'Invalid skip step: {s!r} (valid steps: {STEPS})')
-    skip_steps = set(skip_steps)
-    if start_step is not None:
-        if start_step not in STEPS:
-            raise ValueError(
-                f'Invalid start step: {start_step!r} (valid steps: {STEPS})'
-            )
-        skip_steps.update(STEPS[: STEPS.index(start_step)])
-    if end_step is not None:
-        if end_step not in STEPS:
-            raise ValueError(f'Invalid end step: {end_step!r} (valid steps: {STEPS})')
-        skip_steps.update(STEPS[STEPS.index(end_step) + 1 :])
-    if basic_navigation:
-        skip_steps.add('animate')
-
-    # Standardise file paths
-    root_path = os.path.expandvars(os.path.expanduser(root_path))
-    if background_path is not None:
-        background_path = os.path.expandvars(os.path.expanduser(background_path))
-
-    # Print info
-    log('Running NIRSpec pipeline')
-    log(f'Root path: {root_path!r}', time=False)
-    if skip_steps:
-        log(
-            f'Skipping steps: {", ".join([repr(s) for s in STEPS if s in skip_steps])}',
-            time=False,
-        )
-    else:
-        log('Running all pipeline steps', time=False)
-    log(f'Desaturate: {desaturate!r}', time=False)
-    if groups_to_use:
-        log(f'Groups to keep: {groups_to_use!r}', time=False)
-    if basic_navigation:
-        log(f'Basic navigation: {basic_navigation!r}', time=False)
-    print()
-
-    # Run pipeline steps...
-    if desaturate and 'remove_groups' not in skip_steps:
-        run_remove_groups(root_path, groups_to_use)
-
-    # Create list of paths to reduce (both 'main' dataset and reduced groups)
-    group_root_paths = get_group_root_paths(root_path, desaturate, groups_to_use)
-
-    if 'stage1' not in skip_steps:
-        run_stage1(group_root_paths, stage1_kwargs, reduction_parallel_kwargs)
-
-    if 'stage2' not in skip_steps:
-        run_stage2(group_root_paths, stage2_kwargs, reduction_parallel_kwargs)
-
-    if 'stage3' not in skip_steps:
-        run_stage3(group_root_paths, stage3_kwargs, reduction_parallel_kwargs)
-
-    if 'navigate' not in skip_steps:
-        run_navigate(group_root_paths, basic_navigation, navigate_kwargs)
-
-    if desaturate and 'desaturate' not in skip_steps:
-        run_desaturate(root_path, group_root_paths, desaturate_kwargs, parallel_kwargs)
-
-    if 'despike' not in skip_steps:
-        run_despike(
-            root_path,
-            despike_kwargs,
-            parallel_kwargs,
-            input_stage='stage3_desaturated' if desaturate else 'stage3',
-        )
-
-    if background_path is not None and 'background' not in skip_steps:
-        run_background(root_path, background_path, background_kwargs)
-
-    if 'plot' not in skip_steps:
-        run_plot(group_root_paths, plot_kwargs, parallel_kwargs)
-
-    if 'animate' not in skip_steps:
-        run_animate(root_path, animate_kwargs, parallel_kwargs)
-
-    log('NIRSpec pipeline completed with')
-    log(f'Root path: {root_path!r}', time=False)
-    log(f'Desaturate: {desaturate!r}', time=False)
-    if skip_steps:
-        log(
-            f'Skipped steps: {", ".join([repr(s) for s in STEPS if s in skip_steps])}',
-            time=False,
-        )
-    log('ALL DONE')
-
-
-# remove groups
-def run_remove_groups(root_path: str, groups_to_use: list[int] | None = None) -> None:
-    log('Removing groups')
-    paths_in = sorted(glob.glob(os.path.join(root_path, 'stage0', '*_uncal.fits')))
-    log(f'Processing {len(paths_in)} files...', time=False)
-    for p in tqdm.tqdm(paths_in, desc='remove_groups'):
-        remove_groups.remove_groups_from_file(p, groups_to_use)
-    log('Remove groups step complete\n')
-
-
-def get_group_root_paths(
-    root_path: str, desaturate: bool, groups_to_use: list[int] | None = None
-) -> list[str]:
-    group_root_paths = [root_path]
-    if desaturate:
-        # If desaturating, we also need to reduce the data with fewer groups
-        # This list is sorted such that the number of groups is decreasing (so that the
-        # desaturation works correctly)
-        reduced_group_root_paths = sorted(
-            glob.glob(os.path.join(root_path, 'groups', '*_groups')),
-            reverse=True,
-            key=lambda _p: int(os.path.basename(_p).split('_')[0]),
-        )
-        if groups_to_use is not None:
-            reduced_group_root_paths = [
-                _p
-                for _p in reduced_group_root_paths
-                if int(os.path.basename(_p).split('_')[0]) in groups_to_use
-            ]
-        group_root_paths.extend(reduced_group_root_paths)
-    return group_root_paths
-
-
-# stage1
-def run_stage1(
-    group_root_paths: list[str],
-    stage1_kwargs: dict[str, Any] | None = None,
-    reduction_parallel_kwargs: dict[str, Any] | None = None,
-):
-    log('Running reduction stage 1')
-    kwargs = DEFAULT_STAGE1_KWARGS | (stage1_kwargs or {})
-    log(f'Arguments: {kwargs!r}', time=False)
-    for root_path in group_root_paths:
-        if len(group_root_paths) > 1:
-            log(f'Running reduction stage 1 for {root_path!r}')
-        paths_in = sorted(glob.glob(os.path.join(root_path, 'stage0', '*.fits')))
-        output_dir = os.path.join(root_path, 'stage1')
-        args_list = [(p, output_dir, kwargs) for p in paths_in]
-        log(f'Output directory: {output_dir!r}', time=False)
-        log(f'Processing {len(args_list)} files...', time=False)
-        check_path(output_dir)
-        runmany(
-            reduction_detector1_fn,
-            args_list,
-            desc='stage1',
-            **reduction_parallel_kwargs or {},
-        )
-    log('Reduction stage 1 step complete\n')
-
-
-def reduction_detector1_fn(args: tuple[str, str, dict[str, Any]]) -> None:
-    path_in, output_dir, kwargs = args
-    Detector1Pipeline.call(path_in, output_dir=output_dir, save_results=True, **kwargs)
-
-
-# stage2
-def run_stage2(
-    group_root_paths: list[str],
-    stage2_kwargs: dict[str, Any] | None = None,
-    reduction_parallel_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running reduction stage 2')
-    kwargs = DEFAULT_STAGE2_KWARGS | (stage2_kwargs or {})
-    log(f'Arguments: {kwargs!r}', time=False)
-    for root_path in group_root_paths:
-        if len(group_root_paths) > 1:
-            log(f'Running reduction stage 2 for {root_path!r}')
-        paths_in = sorted(glob.glob(os.path.join(root_path, 'stage1', '*rate.fits')))
-        output_dir = os.path.join(root_path, 'stage2')
-        args_list = [(p, output_dir, kwargs) for p in paths_in]
-        log(f'Output directory: {output_dir!r}', time=False)
-        log(f'Processing {len(args_list)} files...', time=False)
-        check_path(output_dir)
-        runmany(
-            reduction_spec2_fn,
-            args_list,
-            desc='stage2',
-            **reduction_parallel_kwargs or {},
-        )
-    log('Reduction stage 2 step complete\n')
-
-
-def reduction_spec2_fn(args: tuple[str, str, dict[str, Any]]) -> None:
-    path_in, output_dir, kwargs = args
-    try:
-        Spec2Pipeline.call(path_in, output_dir=output_dir, save_results=True, **kwargs)
-    except NoDataOnDetectorError:
-        log(f'No data on detector for {path_in!r}, skipping')
-
-
-# stage3
-def run_stage3(
-    group_root_paths: list[str],
-    stage3_kwargs: dict[str, Any] | None = None,
-    reduction_parallel_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running reduction stage 3')
-    kwargs = DEFAULT_STAGE3_KWARGS | (stage3_kwargs or {})
-    log(f'Arguments: {kwargs!r}', time=False)
-
-    for root_path in group_root_paths:
-        if len(group_root_paths) > 1:
-            log(f'Running reduction stage 3 for {root_path!r}')
-
-        grouped_files = group_stage2_files_for_stage3(root_path)
-
-        # Only need to include the tile in prodname if it is needed to avoid filename
-        # collisions for observations which use mosaicing. Most observations just have a
-        # single tile per datset, so we can just use the standard prodname in this case
-        keys_with_tiles = set(grouped_files.keys())
-        keys_without_tiles = set(
-            (dither, filter_, grating)
-            for dither, tile, filter_, grating in keys_with_tiles
-        )
-        include_tile_in_prodname = len(keys_with_tiles) != len(keys_without_tiles)
-
-        asn_paths_list: list[tuple[str, str]] = []
-        for (dither, tile, filter_, grating), paths in grouped_files.items():
-            dirname = 'combined' if dither is None else f'd{dither}'
-            output_dir = os.path.join(root_path, 'stage3', dirname)
-            check_path(output_dir)
-            asn_path = os.path.join(
-                output_dir, f'l3asn-{tile}_{filter_}_{grating}_dither-{dirname}.json'
-            )
-            write_asn_for_stage3(
-                paths,
-                asn_path,
-                prodname='Level3' + (f'_{tile}' if include_tile_in_prodname else ''),
-            )
-            asn_paths_list.append((asn_path, output_dir))
-        args_list = [
-            (p, output_dir, kwargs) for p, output_dir in sorted(asn_paths_list)
-        ]
-        log(f'Processing {len(args_list)} files...', time=False)
-        runmany(
-            reduction_spec3_fn,
-            args_list,
-            desc='stage3',
-            **reduction_parallel_kwargs or {},
-        )
-    log('Reduction stage 3 step complete\n')
-
-
-def group_stage2_files_for_stage3(
-    root_path: str,
-) -> dict[tuple[int | None, str, str, str], list[str]]:
-    out: dict[tuple[int | None, str, str, str], list[str]] = {}
-    paths_in = sorted(glob.glob(os.path.join(root_path, 'stage2', '*_cal.fits')))
-    for p in paths_in:
-        with fits.open(p) as hdul:
-            hdr = hdul[0].header  #  type: ignore
-        dither = int(hdr['PATT_NUM'])
-        tile = hdr['ACT_ID']
-        filter_ = hdr['FILTER']
-        grating = hdr['GRATING']
-
-        # Keep dithers separate
-        k = (dither, tile, filter_, grating)
-        out.setdefault(k, []).append(p)
-
-        # Combine dithers
-        k = (None, tile, filter_, grating)
-        out.setdefault(k, []).append(p)
-    return out
-
-
-def write_asn_for_stage3(
-    files: list[str], asnfile: str, prodname: str, **kwargs
-) -> str:
-    asn = asn_from_list(files, rule=DMS_Level3_Base, product_name=prodname)
-    if 'bg' in kwargs:
-        for bgfile in kwargs['bg']:
-            asn['products'][0]['members'].append(
-                {'expname': bgfile, 'exptype': 'background'}
-            )
-    _, serialized = asn.dump()
-    with open(asnfile, 'w', encoding='utf-8') as outfile:
-        outfile.write(serialized)
-    return asnfile
-
-def reduction_spec3_fn(args: tuple[str, str, dict[str, Any]]) -> None:
-    asn_path, output_dir, kwargs = args
-    Spec3Pipeline.call(
-        asn_path,
-        output_dir=output_dir,
-        save_results=True,
-        **kwargs,
+    pipeline.run(
+        skip_steps=skip_steps,
+        start_step=start_step,
+        end_step=end_step,
     )
 
 
-# navigation
-def run_navigate(
-    group_root_paths: list[str],
-    basic_navigation: bool = False,
-    navigate_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running navigate')
-    kwargs = DEFAULT_NAVIGATE_KWARGS | (navigate_kwargs or {})
-    log(f'Basic navigation: {basic_navigation!r}', time=False)
-    log(f'Arguments: {kwargs!r}', time=False)
-    navigate_jwst_observations.load_kernels()
-    for root_path in group_root_paths:
-        if len(group_root_paths) > 1:
-            log(f'Running navigation for {root_path!r}')
-        paths_in = sorted(
-            glob.glob(os.path.join(root_path, 'stage3', '*', '*_s3d.fits'))
-        )
-        navigate_jwst_observations.navigate_multiple(
-            *paths_in, basic=basic_navigation, **kwargs
-        )
-    log('Navigate step complete\n')
+class NirspecPipeline(Pipeline):
+    @staticmethod
+    def get_instrument() -> str:
+        return 'NIRSpec'
 
+    @property
+    def steps(self) -> tuple[Step, ...]:
+        return STEPS
 
-# desaturate
-def run_desaturate(
-    root_path: str,
-    group_root_paths: list[str],
-    desaturate_kwargs: dict[str, Any] | None = None,
-    parallel_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running desaturate')
-    kwargs = DEFAULT_DESATURATE_KWARGS | (desaturate_kwargs or {})
-    parallel_kwargs = parallel_kwargs or {}
-    log(f'Arguments: {kwargs!r}', time=False)
+    @property
+    def default_kwargs(self) -> dict[Step, dict[str, Any]]:
+        return DEFAULT_KWARGS
 
-    paths_dict: dict[str, list[str]] = {}
-    for rp in group_root_paths:
-        paths_in = sorted(glob.glob(os.path.join(rp, 'stage3', '*_nav', '*_nav.fits')))
-        for p_in in paths_in:
-            relpath = os.path.relpath(p_in, rp)
-            relpath = replace_path_part(
-                relpath, -3, 'stage3_desaturated', check_old='stage3'
-            )
-            p_out = os.path.join(root_path, relpath)
-            paths_dict.setdefault(p_out, []).append(p_in)
-    args_list = [(paths_in, p_out, kwargs) for p_out, paths_in in paths_dict.items()]
-    log(f'Processing {len(args_list)} output files...', time=False)
-    runmany(desaturate_fn, args_list, desc='desaturate', **parallel_kwargs)
-    log('Desaturate step complete\n')
+    @property
+    def step_directories(self) -> dict[Step, tuple[str, str]]:
+        directories = super().step_directories | STEP_DIRECTORIES
+        dir_in = 'stage3_desaturated' if self.desaturate else 'stage3'
+        directories['despike'] = (dir_in, directories['despike'][1])
+        return directories
 
+    @property
+    def stage3_file_match_hdr_keys(self) -> tuple[str, ...]:
+        return ('FILTER', 'GRATING')
 
-def desaturate_fn(args: tuple[list[str], str, dict[str, Any]]) -> None:
-    paths_in, path_out, kwargs = args
-    desaturate_data.replace_saturated(paths_in, path_out, **kwargs)
+    @property
+    def stage_directories_to_plot(self) -> tuple[str, ...]:
+        return STAGE_DIRECTORIES_TO_PLOT
 
-
-# despike
-def run_despike(
-    root_path: str,
-    despike_kwargs: dict[str, Any] | None = None,
-    parallel_kwargs: dict[str, Any] | None = None,
-    input_stage: str = 'stage3',
-) -> None:
-    log('Running despike')
-    paths_in = sorted(
-        glob.glob(os.path.join(root_path, input_stage, '*_nav', '*_nav.fits'))
-    )
-    paths_out = [
-        replace_path_part(p, -3, 'stage4_despike', check_old=input_stage)
-        for p in paths_in
-    ]
-    parallel_kwargs = parallel_kwargs or {}
-    kwargs = DEFAULT_DESPIKE_KWARGS | (despike_kwargs or {})
-    if parallel_kwargs.get('parallel_frac', False):
-        kwargs.setdefault('progress_bar', False)
-    args_list = [(p_in, p_out, kwargs) for p_in, p_out in zip(paths_in, paths_out)]
-    log(f'Arguments: {kwargs!r}', time=False)
-    log(f'Processing {len(args_list)} files...', time=False)
-    runmany(despike_fn, args_list, desc='despike', **parallel_kwargs)
-    log('Despike step complete\n')
-
-
-def despike_fn(args: tuple[str, str, dict[str, Any]]) -> None:
-    p_in, p_out, kwargs = args
-    despike_data.despike_cube(p_in, p_out, **kwargs)
-
-
-# background
-def run_background(
-    root_path: str,
-    background_path: str,
-    background_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running background')
-    kwargs = DEFAULT_BACKGROUND_KWARGS | (background_kwargs or {})
-    log(f'Arguments: {kwargs!r}', time=False)
-
-    paths_in = sorted(
-        glob.glob(os.path.join(root_path, 'stage4_despike', 'd*_nav', '*_nav.fits'))
-    )
-    log(f'Processing {len(paths_in)} input files...', time=False)
-    for p_in in tqdm.tqdm(paths_in, desc='background'):
-        p_out = replace_path_part(
-            p_in, -3, 'stage5_background', check_old='stage4_despike'
-        )
-        with fits.open(p_in) as hdul:
-            hdr = hdul['PRIMARY'].header  #  type: ignore
-        p_background = os.path.join(
-            background_path,
-            'stage4_despike',
-            'd{dither}_nav',
-            'Level3_{grating}-{filter}_s3d_nav.fits',
-        ).format(
-            grating=hdr['GRATING'].lower(),
-            filter=hdr['FILTER'].lower(),
-            dither='1',
-        )
-        background_subtraction.subtract_background(p_in, p_out, p_background, **kwargs)
-    log('Background step complete\n')
-
-
-# plot
-def run_plot(
-    group_root_paths: list[str],
-    plot_kwargs: dict[str, Any] | None = None,
-    parallel_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running plot')
-    kwargs = DEFAULT_PLOT_KWARGS | (plot_kwargs or {})
-    parallel_kwargs = parallel_kwargs or {}
-    log(f'Arguments: {kwargs!r}', time=False)
-    for root_path in group_root_paths:
-        if len(group_root_paths) > 1:
-            log(f'Generating quick look plots for {root_path!r}')
-        for stage in reversed(DATA_STAGES):
-            log(f'Generating quick look plots for stage {stage!r}')
-            paths_in = sorted(
-                glob.glob(os.path.join(root_path, stage, '*_nav', '*_nav.fits'))
-            )
-            paths_out = [
-                replace_path_part(p, -3, os.path.join('plots', stage), check_old=stage)
-                for p in paths_in
-            ]
-            paths_out = [
-                replace_path_suffix(p, '.png', check_old='.fits') for p in paths_out
-            ]
-            args_list = [
-                (p_in, p_out, kwargs) for p_in, p_out in zip(paths_in, paths_out)
-            ]
-            log(f'Processing {len(args_list)} files...', time=False)
-            runmany(plot_fn, args_list, desc='plot', **parallel_kwargs)
-    log('Plot step complete\n')
-
-
-def plot_fn(args: tuple[str, str, dict[str, Any]]) -> None:
-    p_in, p_out, kwargs = args
-    jwst_summary_plots.make_summary_plot(p_in, p_out, **kwargs)
-
-
-# animate
-def run_animate(
-    root_path: str,
-    animate_kwargs: dict[str, Any] | None = None,
-    parallel_kwargs: dict[str, Any] | None = None,
-) -> None:
-    log('Running animate')
-    kwargs = DEFAULT_ANIMATE_KWARGS | (animate_kwargs or {})
-    parallel_kwargs = parallel_kwargs or {}
-    if parallel_kwargs.get('parallel_frac', False):
-        kwargs.setdefault('progress_bar', False)
-    log(f'Arguments: {kwargs!r}', time=False)
-    for stage in reversed(DATA_STAGES):
-        log(f'Generating quick look animations for stage {stage!r}')
-        paths_in = sorted(
-            glob.glob(os.path.join(root_path, stage, 'd*_nav', '*_nav.fits'))
-        )
-        paths_dict: dict[str, list[str]] = {}
-        for p_in in paths_in:
-            filename = os.path.basename(
-                replace_path_suffix(p_in, '.mp4', check_old='.fits')
-            )
-            p_out = os.path.join(root_path, 'animation', stage, filename)
-            paths_dict.setdefault(p_out, []).append(p_in)
-        args_list = [
-            (paths_in, p_out, kwargs) for p_out, paths_in in paths_dict.items()
-        ]
-        log(f'Processing {len(args_list)} files...', time=False)
-        runmany(animation_fn, args_list, desc='animate', **parallel_kwargs)
-    log('Animate step complete\n')
-
-
-def animation_fn(args: tuple[list[str], str, dict[str, Any]]) -> None:
-    paths_in, p_out, kwargs = args
-    jwst_summary_animation.make_animation(paths_in, p_out, **kwargs)
-
-
-# utils
-def replace_path_part(
-    path: str, idx: int, new: str, *, check_old: str | None = None
-) -> str:
-    """
-    Replace a part of a path with a new value.
-
-    Args:
-        path: The path to modify.
-        idx: The index of the part to replace in the directory tree.
-        new: The new value to use.
-        check_old: If not None, check that the value at the index is this value
-            before replacing it.
-
-    Returns:
-        The modified path.
-    """
-    p = pathlib.Path(path)
-    parts = list(p.parts)
-    if check_old is not None and parts[idx] != check_old:
-        raise ValueError(f'Expected {check_old!r} at index {idx} in {path!r}')
-    parts[idx] = new
-    return str(pathlib.Path(*parts))
-
-
-def replace_path_suffix(path: str, new: str, *, check_old: str | None = None) -> str:
-    """
-    Replace the suffix of a path with a new value.
-
-    Args:
-        path: The path to modify.
-        new: The new value to use.
-        check_old: If not None, check that the suffix is this value before
-            replacing it.
-
-    Returns:
-        The modified path.
-    """
-    p = pathlib.Path(path)
-    if check_old is not None and p.suffix != check_old:
-        raise ValueError(f'Expected {check_old!r} suffix in {path!r}')
-    return str(p.with_suffix(new))
+    # Step overrides
+    def reduction_spec2_fn(self, args: tuple[str, str, dict[str, Any]]) -> None:
+        try:
+            return super().reduction_spec2_fn(args)
+        except NoDataOnDetectorError:
+            path_in, output_dir, kwargs = args
+            print(f'No data on detector for {path_in!r}, skipping')
 
 
 def main():
-    # Parse command line arguments
-    parser = argparse.ArgumentParser(
-        description=(
-            'Full JWST NIRSpec IFU pipeline including the standard reduction from '
-            'stage0 to stage3, and custom pipeline steps for additional cleaning and '
-            'data visualisation. For more customisation, this script can be imported '
-            'and run in Python (see the source code for mode details).\n\n'
-            'The following steps are run in the full pipeline:' + STEP_DESCRIPTIONS
-        ),
-        epilog=CLI_EXAMPLES,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        argument_default=argparse.SUPPRESS,
+    parser = get_pipeline_argument_parser(
+        NirspecPipeline, STEP_DESCRIPTIONS, CLI_EXAMPLES
     )
-    parser.add_argument(
-        'root_path',
-        type=str,
-        help="""Path to the directory containing the data. This directory should
-            contain a subdirectory with the stage0 data (i.e. `root_path/stage0`).
-            Additional directories will be created automatically for each step of the
-            pipeline (e.g. `root_path/stage1`, `root_path/plots` etc.).""",
-    )
-    parser.add_argument(
-        '--desaturate',
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="""Toggle desaturation of the data. If desaturation is enabled the 
-            `reduction` step will be run for different numbers of groups, which are then
-            combined in the `desaturate` step to produce a desaturated data cube. This
-            desaturation is enabled by default.
-            """,
-    )
-    parser.add_argument(
-        '--parallel',
-        nargs='?',
-        const=1,
-        type=float,
-        help="""Fraction of CPU cores to use when multiprocessing. For example, set 
-        0.5 to use half of the available cores. If unspecified, then multiprocessing 
-        will not be used and the pipeline will be run serially. If specified but no 
-        value is given, then all available cores will be used (i.e. `--parallel` is 
-        equivalent to `--parallel 1`).""",
-    )
-    parser.add_argument(
-        '--groups_to_use',
-        type=str,
-        help="""Comma-separated list of groups to keep. For example, `1,2,3,4` will
-            keep the first four groups. If unspecified, all groups will be kept.""",
-    )
-    parser.add_argument(
-        '--background_path',
-        type=str,
-        help="""Path to directory containing background data. For example, if
-            your `root_path` is `/data/uranus/lon1`, the `background_path` may
-            be `/data/uranus/background`. Note that background subtraction will
-            require the background data to be already reduced. If no `background_path`
-            is specified (the default), then no background subtraction will be 
-            performed.""",
-    )
-    parser.add_argument(
-        '--basic_navigation',
-        action='store_true',
-        help="""Use basic navigation, and only save RA and Dec backplanes (e.g. useful
-            for small bodies). By default, full navigation is performed, generating a
-            full set of coordinate backplanes (lon/lat, illumination angles etc.). Using
-            basic navigation automatically skips the navigation step.""",
-    )
-    parser.add_argument(
-        '--skip_steps',
-        nargs='+',
-        type=str,
-        help="""List of steps to skip. This is generally only useful if you are
-            re-running part of the pipeline. Multiple steps can be passed as a
-            space-separated list. For example, `--skip_steps flat despike`.""",
-    )
-    parser.add_argument(
-        '--start_step',
-        type=str,
-        help="""Convenience argument to add all steps before `start_step` to 
-            `skip_steps`.""",
-    )
-    parser.add_argument(
-        '--end_step',
-        type=str,
-        help="""Convenience argument to add all steps steps after `end_step` to 
-            `skip_steps`.""",
-    )
-    parser.add_argument(
-        '--kwargs',
-        type=str,
-        help="""JSON string containing keyword arguments to pass to individual pipeline
-            steps. For example, 
-            `--kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "animation": {"radius_factor": 2.5}}'` 
-            will pass the custom arguments to the stage3 and animation steps.
-            """,
-    )
-    args = vars(parser.parse_args())
-    json_kwargs = args.pop('kwargs', None)
-    if json_kwargs:
-        json_kwargs = json.loads(json_kwargs)
-        for k, v in json_kwargs.items():
-            if not k.endswith('_kwargs'):
-                k = k + '_kwargs'
-            args[k] = v
-    if 'groups_to_use' in args:
-        args['groups_to_use'] = [int(g) for g in args['groups_to_use'].split(',')]
-    run_pipeline(**args)
+    run_pipeline(**vars(parser.parse_args()))
 
 
 if __name__ == '__main__':

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -76,7 +76,7 @@ data cubes which can be used for science. Within each science directory (`stage3
 - `stage3/d1` contains the stage3 data for dither 1
 - `stage3/d2_bg` contains the stage3 data for dither 2 with the background subtracted
 - `stage3/combined` contains the stage4 data with all dithers combined
-- `stage4_flat/d3` contains the stage4 for dither 3
+- `stage4_despike/d3` contains the stage4 for dither 3
 
 The `plots` and `animation` directories contain quick look visualisations of the data.
 

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -56,6 +56,16 @@ or from Python ::
 This will run the full pipeline, and output data files appropriate directories (e.g. 
 `/data/uranus/lon1/stage3`, `/data/uranus/lon1/plots` etc.).
 
+If the pipeline is run with desaturation enabled, the pipeline flow is:
+- Firstly, multiple versions of the stage0 cubes are greated with different numbers of 
+  groups (the `remove_groups` step).
+- `stage1` is run on e.g. the 4 group data, then the 3 group data, then the 2 group
+  data, then the 1 group data. Then `stage2` is run on the 4-1 group data, then 
+  `stage3`, then `navigate`.
+- The `desaturate` step is then run to combine the various group data into a single
+  desaturated dataset.
+- Subsequent pipeline steps (e.g. `plot`) are run on the desaturated data.
+
 For more command line examples, see CLI_EXAMPLES below, and for more Python examples,
 see the docstring for `run_pipeline()` below.
 
@@ -74,6 +84,7 @@ don't need to create it yourself) ::
 
 See https://jwst-pipeline.readthedocs.io/en/latest/jwst/stpipe/user_logging.html for
 more details.
+
 
 Example ALICE HPC job submission script
 =======================================
@@ -145,6 +156,9 @@ python3 nirspec_pipeline.py /data/uranus/lon1 --no-desaturate
 
 # Run the pipeline, but stop before creating any visualisations
 python3 nirspec_pipeline.py /data/uranus/lon1 --end_step despike
+
+# Only run the plotting step
+python3 nirspec_pipeline.py /data/uranus/lon1 --start_step plot --end_step plot
 
 # Re-run the pipeline, skipping the initial reduction steps
 python3 nirspec_pipeline.py /data/uranus/lon1 --start_step desaturate

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -361,7 +361,6 @@ def run_pipeline(
         if end_step not in STEPS:
             raise ValueError(f'Invalid end step: {end_step!r} (valid steps: {STEPS})')
         skip_steps.update(STEPS[STEPS.index(end_step) + 1 :])
-
     if basic_navigation:
         skip_steps.add('animate')
 

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -593,7 +593,7 @@ def run_stage3(
             output_dir = os.path.join(root_path, 'stage3', dirname)
             check_path(output_dir)
             asn_path = os.path.join(
-                output_dir, f'l3asn-{tile}_{filter_}_{grating}_dither-{dither}.json'
+                output_dir, f'l3asn-{tile}_{filter_}_{grating}_dither-{dirname}.json'
             )
             write_asn_for_stage3(
                 paths,

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -98,7 +98,7 @@ you may need to increase the walltime and decrease the number of nodes (ppn).
 
 To use this script you will need to:
 - replace `py310` in the `conda activate` line to the name of your conda environment
-- replace the two references to `/data/.../SATURN-15N` with the path to your data :: 
+- replace the two references to `/data/uranus/lon1` with the path to your data :: 
 
     #!/bin/bash
     #
@@ -552,11 +552,10 @@ def run_stage3(
             output_dir = os.path.join(root_path, 'stage3', dirname)
             check_path(output_dir)
             asn_path = os.path.join(
-                output_dir, f'l3asn-{tile}_{filter_}_{grating}.json'
+                output_dir, f'l3asn-{tile}_{filter_}_{grating}_dither-{dither}.json'
             )
             write_asn_for_stage3(paths, asn_path, prodname=f'Level3_{tile}')
             asn_paths_list.append((asn_path, output_dir))
-
         args_list = [
             (p, output_dir, kwargs) for p, output_dir in sorted(asn_paths_list)
         ]
@@ -590,11 +589,12 @@ def group_stage2_files_for_stage3(
         # Combine dithers
         k = (None, tile, filter_, grating)
         out.setdefault(k, []).append(p)
-
     return out
 
 
-def write_asn_for_stage3(files: list, asnfile: str, prodname: str, **kwargs) -> None:
+def write_asn_for_stage3(
+    files: list[str], asnfile: str, prodname: str, **kwargs
+) -> None:
     asn = asn_from_list(files, rule=DMS_Level3_Base, product_name=prodname)
     if 'bg' in kwargs:
         for bgfile in kwargs['bg']:

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -759,7 +759,7 @@ def run_background(
     log(f'Arguments: {kwargs!r}', time=False)
 
     paths_in = sorted(
-        glob.glob(os.path.join(root_path, 'stage4_despike', '*_nav', '*_nav.fits'))
+        glob.glob(os.path.join(root_path, 'stage4_despike', 'd*_nav', '*_nav.fits'))
     )
     log(f'Processing {len(paths_in)} input files...', time=False)
     for p_in in tqdm.tqdm(paths_in, desc='background'):

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -641,7 +641,7 @@ def group_stage2_files_for_stage3(
 
 def write_asn_for_stage3(
     files: list[str], asnfile: str, prodname: str, **kwargs
-) -> None:
+) -> str:
     asn = asn_from_list(files, rule=DMS_Level3_Base, product_name=prodname)
     if 'bg' in kwargs:
         for bgfile in kwargs['bg']:
@@ -651,7 +651,7 @@ def write_asn_for_stage3(
     _, serialized = asn.dump()
     with open(asnfile, 'w', encoding='utf-8') as outfile:
         outfile.write(serialized)
-
+    return asnfile
 
 def reduction_spec3_fn(args: tuple[str, str, dict[str, Any]]) -> None:
     asn_path, output_dir, kwargs = args

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -169,7 +169,7 @@ python3 nirspec_pipeline.py /data/uranus/lon1 --start_step plot --end_step plot
 python3 nirspec_pipeline.py /data/uranus/lon1 --start_step desaturate
 
 # Run the pipeline, passing custom arguments to different steps
-python3 nirspec_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "plot": {"plot_brightest_spectrum": false}, "animation": {"radius_factor": 2.5}}'
+python3 nirspec_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "plot": {"plot_brightest_spectrum": true}}'
 """
 from typing import Any, Collection, Literal
 
@@ -266,7 +266,7 @@ def run_pipeline(
                 'stage3: {
                     'outlier_detection': {'snr': '30.0 24.0', 'scale': '1.3 0.7'}
                 },
-                'plot': {'plot_brightest_spectrum': False},
+                'plot': {'plot_brightest_spectrum': True},
                 'animate': {'radius_factor': 2.5},
             },
         )
@@ -320,7 +320,7 @@ def run_pipeline(
         reduction_parallel_kwargs: Dictionary of keyword arguments to customise parallel
             processing for the reduction steps (i.e. `stage1`-`stage3`). This will be
             merged with `parallel_kwargs` (i.e.
-            `parallel_kwargs | reduction_parallel_kwargs
+            `parallel_kwargs | reduction_parallel_kwargs`).
     """
     pipeline = NirspecPipeline(
         root_path,

--- a/nirspec_pipeline_old.py
+++ b/nirspec_pipeline_old.py
@@ -1,0 +1,1022 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This old version of the NIRSpec pipeline is kept for backwards compatibility. It is
+only kept here for reference and backwards compatibility. All new development should
+be done in nirspec_pipeline.py.
+
+
+
+Full JWST reduction pipeline for NIRSpec IFU data, including the standard reduction from
+stage0 to stage3, and custom pipeline steps for additional cleaning and data 
+visualisation.
+
+See STEP_DESCRIPTIONS below for a description of each step in this pipeline.
+
+GitHub repository: https://github.com/JWSTGiantPlanets/pipelines
+
+
+Setup
+=====
+If you are running a reduction on Leicester's ALICE HPC then the pipeline should work 
+out of the box without any additional setup - see the example job submission script 
+below. If you are running the pipeline on another machine, you will need to set up the
+correct environment to run the pipeline:
+
+The `stage1`-`stage3` steps of the pipeline require the following environment variables
+to be set to load the and cache the appropriate CRDS reference files ::
+
+    export CRDS_PATH="path/to/crds_cache"
+    export CRDS_SERVER_URL="https://jwst-crds.stsci.edu"
+
+If you are starting with an empty CRDS cache, the pipeline will have to download several
+GB of reference files, so the first run will be much slower. If you are getting errors
+when the reduction pipeline is reading/writing CRDS reference files, try running the 
+reduction step serially (i.e. without the `--parallel` flag) to avoid any potential race
+conditions caused by multiple processes trying to simultaneously download the same 
+reference files.
+
+The navigation and visualisation steps use SPICE kernels to calculate the observation
+geometry. The pipeline will attempt to automatically find the SPICE kernels, but this 
+will generally only work if they are saved in `~/spice_kernels` or you are running the
+code on ALICE. Therefore, the location of these kernels can customised by setting the
+environment variable ::
+
+    export PLANETMAPPER_KERNEL_PATH="path/to/spice_kernels"
+
+For more information on downloading and saving the SPICE kernels, see 
+https://planetmapper.readthedocs.io/en/latest/spice_kernels.html.
+
+
+Usage
+=====
+The pipeline can be run from the command line, or imported and run from Python. To run
+the pipeline to fully reduce a dataset, simply download the stage0 (e.g. to 
+`/data/uranus/lon1/stage0`), then run the following command on the command line ::
+
+    python3 nirspec_pipeline.py /data/uranus/lon1
+
+or from Python ::
+
+    import nirspec_pipeline
+    nirspec_pipeline.run_pipeline('/data/uranus/lon1')
+
+This will run the full pipeline, and output data files appropriate directories (e.g. 
+`/data/uranus/lon1/stage3`, `/data/uranus/lon1/plots` etc.).
+
+If the pipeline is run with desaturation enabled, the pipeline flow is:
+- Firstly, multiple versions of the stage0 cubes are created with different numbers of 
+  groups (the `remove_groups` step).
+- `stage1` is run on e.g. the 4 group data, then the 3 group data, then the 2 group
+  data, then the 1 group data. Then `stage2` is run on the 4-1 group data, then 
+  `stage3`, then `navigate`.
+- The `desaturate` step is then run to combine the various group data into a single
+  desaturated dataset.
+- Subsequent pipeline steps (e.g. `plot`) are run on the desaturated data.
+
+For more command line examples, see CLI_EXAMPLES below, and for more Python examples,
+see the docstring for `run_pipeline()` below.
+
+
+Customising logging
+===================
+The the `reduction` step of the pipeline can print a large amount of information to the 
+terminal. To prevent this, you can create a `stpipe-log.cfg` file in your working 
+directory, with the following contents to redirect the output to a file named 
+`pipeline.log` (this `pipeline.log` file will be created automatically if needed, so you
+don't need to create it yourself) ::
+
+    [*]
+    handler = append:pipeline.log
+    level = WARNING
+
+See https://jwst-pipeline.readthedocs.io/en/latest/jwst/stpipe/user_logging.html for
+more details.
+
+
+Example ALICE HPC job submission script
+=======================================
+The following example job submission script will run the pipeline on ALICE, using
+multiprocessing for the `reduction` step. The chmod commands at the end change the 
+permissions on data and CRDS cache files so that any new/modified files can be accessed 
+by other users in the future.
+
+Depending on the number of dithers/groups/integrations etc. for your data,
+you may need to increase the walltime and decrease the number of nodes (ppn).
+
+To use this script you will need to:
+- replace `py310` in the `conda activate` line to the name of your conda environment
+- replace the two references to `/data/uranus/lon1` with the path to your data :: 
+
+    #!/bin/bash
+    #
+    #PBS -N NIRSpec_Pipeline
+    #PBS -l walltime=24:00:00
+    #PBS -l vmem=80gb
+    #PBS -l nodes=1:ppn=4
+    
+    source ~/.bashrc 
+    conda activate py310 # <-- replace this with the name of your conda environment
+
+    export CRDS_PATH="/data/nemesis/jwst/crds_cache"
+    export CRDS_SERVER_URL="https://jwst-crds.stsci.edu"
+
+    # Optionally redirect the verbose `reduction` step output to the file `pipeline.log`
+    if [ -f "/data/nemesis/jwst/scripts/oliver/pipelines/stpipe-log.cfg" ]; then
+        cp -f "/data/nemesis/jwst/scripts/oliver/pipelines/stpipe-log.cfg" .
+        echo "Copied stpipe-log.cfg to current working directory"
+    fi
+
+    # Run the pipeline
+    python3 /data/nemesis/jwst/scripts/oliver/pipelines/nirspec_pipeline.py /data/uranus/lon1 --parallel
+    
+    # Change permissions on modified files so that other users can use them
+    chmod -R --quiet 777 /data/uranus/lon1
+    chmod -R --quiet 777 $CRDS_PATH
+"""
+STEP_DESCRIPTIONS = """
+- `remove_groups`: Remove groups from the data (for use in desaturating the data) [optional].
+- `stage1`: Run the standard JWST reduction pipeline stage 1.
+- `stage2`: Run the standard JWST reduction pipeline stage 2.
+- `stage3`: Run the standard JWST reduction pipeline stage 3.
+- `navigate`: Navigate reduced files.
+- `desaturate`: Desaturate data using cubes with fewer groups [optional].
+- `despike`: Clean cubes by removing extreme outlier pixels.
+- `background`: Subtract background from cubes [optional].
+- `plot`: Generate quick look summary plots of data.
+- `animate`: Generate summary animations of data.
+"""
+CLI_EXAMPLES = """examples:
+
+# Print a help message, including documentation for each argument
+python3 nirspec_pipeline.py -h
+
+# Run the full pipeline with all steps enabled
+python3 nirspec_pipeline.py /data/uranus/lon1
+
+# Run the full pipeline in parallel using all cores
+python3 nirspec_pipeline.py /data/uranus/lon1 --parallel
+
+# Run the full pipeline in parallel, using 50% of available cores
+python3 nirspec_pipeline.py /data/uranus/lon1 --parallel 0.5
+
+# Run the full pipeline, without any desaturation
+python3 nirspec_pipeline.py /data/uranus/lon1 --no-desaturate
+
+# Run the pipeline, including background subtraction
+python3 nirspec_pipeline.py /data/uranus/lon1 --background_path /data/uranus/background
+
+# Run the pipeline, but stop before creating any visualisations
+python3 nirspec_pipeline.py /data/uranus/lon1 --end_step despike
+
+# Only run the plotting step
+python3 nirspec_pipeline.py /data/uranus/lon1 --start_step plot --end_step plot
+
+# Re-run the pipeline, skipping the initial reduction steps
+python3 nirspec_pipeline.py /data/uranus/lon1 --start_step desaturate
+
+# Run the pipeline, passing custom arguments to different steps
+python3 nirspec_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "plot": {"plot_brightest_spectrum": true}, "animation": {"radius_factor": 2.5}}'
+"""
+import argparse
+import glob
+import json
+import os
+import pathlib
+from typing import Any, Literal, TypeAlias
+
+import tqdm
+from astropy.io import fits
+from jwst.assign_wcs.util import NoDataOnDetectorError
+from jwst.associations.asn_from_list import asn_from_list
+from jwst.associations.lib.rules_level3_base import DMS_Level3_Base
+from jwst.pipeline import Detector1Pipeline, Spec2Pipeline, Spec3Pipeline
+
+import background_subtraction
+import desaturate_data
+import despike_data
+import jwst_summary_animation
+import jwst_summary_plots
+import navigate_jwst_observations
+import remove_groups
+from parallel_tools import runmany
+from tools import check_path, log
+
+Step: TypeAlias = Literal[
+    'remove_groups',
+    'stage1',
+    'stage2',
+    'stage3',
+    'navigate',
+    'desaturate',
+    'despike',
+    'background',
+    'plot',
+    'animate',
+]
+STEPS: list[Step] = [
+    'remove_groups',
+    'stage1',
+    'stage2',
+    'stage3',
+    'navigate',
+    'desaturate',
+    'despike',
+    'background',
+    'plot',
+    'animate',
+]
+
+DATA_STAGES = [
+    'stage3',
+    'stage3_desaturated',
+    'stage4_despike',
+    'stage5_background',
+]
+
+# Default arguments for each step. These are merged with the user-supplied kwargs
+# before being passed to the pipeline, for example:
+# stage1_kwargs = DEFAULT_STAGE1_KWARGS | stage1_kwargs
+DEFAULT_STAGE1_KWARGS = {}
+DEFAULT_STAGE2_KWARGS = {
+    'steps': {'cube_build': {'coord_system': 'ifualign'}, 'extract_1d': {'skip': True}}
+}
+DEFAULT_STAGE3_KWARGS = {
+    'steps': {'cube_build': {'coord_system': 'ifualign'}, 'extract_1d': {'skip': True}}
+}
+DEFAULT_DESATURATE_KWARGS = {}
+DEFAULT_NAVIGATE_KWARGS = {}
+DEFAULT_DESPIKE_KWARGS = {}
+DEFAULT_BACKGROUND_KWARGS = {}
+DEFAULT_PLOT_KWARGS = {}
+DEFAULT_ANIMATE_KWARGS = {}
+
+
+def run_pipeline(
+    root_path: str,
+    *,
+    desaturate: bool = True,
+    groups_to_use: list[int] | None = None,
+    background_path: str | None = None,
+    parallel: float | bool = False,
+    basic_navigation: bool = False,
+    skip_steps: list[Step] | set[Step] | None = None,
+    start_step: Step | None = None,
+    end_step: Step | None = None,
+    stage1_kwargs: dict[str, Any] | None = None,
+    stage2_kwargs: dict[str, Any] | None = None,
+    stage3_kwargs: dict[str, Any] | None = None,
+    desaturate_kwargs: dict[str, Any] | None = None,
+    navigate_kwargs: dict[str, Any] | None = None,
+    despike_kwargs: dict[str, Any] | None = None,
+    background_kwargs: dict[str, Any] | None = None,
+    plot_kwargs: dict[str, Any] | None = None,
+    animate_kwargs: dict[str, Any] | None = None,
+    parallel_kwargs: dict[str, Any] | None = None,
+    reduction_parallel_kwargs: dict[str, Any] | None = None,
+) -> None:
+    """
+    Run the full NIRSpec IFU reduction pipeline, including the standard reduction from
+    stage0 to stage3, and custom pipeline steps for additional cleaning and data
+    visualisation.
+
+    Examples ::
+
+        from nirspec_pipeline import run_pipeline
+
+        # Run the full pipeline with all steps enabled
+        run_pipeline('/data/uranus/lon1')
+
+        # Run the full pipeline in parallel, using 50% of available cores
+        run_pipeline('/data/uranus/lon1', parallel=0.5)
+
+        # Run the full pipeline, without any desaturation
+        run_pipeline('/data/uranus/lon1', desaturate=False)
+
+        # Run the pipeline, including background subtraction
+        run_pipeline(
+            '/data/uranus/lon1',
+            background_path='data/uranus/background',
+        )
+
+        # Run the pipeline, but stop before creating any visualisations
+        run_pipeline('/data/uranus/lon1', end_step='despike')
+
+        # Re-run the pipeline, skipping the initial reduction steps
+        run_pipeline('/data/uranus/lon1', start_step='desaturate')
+
+        # Run the pipeline, passing custom arguments to different steps
+        run_pipeline(
+            '/data/uranus/lon1',
+            stage3_kwargs={
+                'outlier_detection': {'snr': '30.0 24.0', 'scale': '1.3 0.7'}
+            },
+            plot_kwargs={'plot_brightest_spectrum': True},
+            animation_kwargs={'radius_factor': 2.5},
+        )
+
+    Args:
+        root_path: Path to the root directory containing the data. This directory should
+            contain a subdirectory with the stage 0 data (i.e. `root_path/stage0`).
+            Additional directories will be created automatically for each step of the
+            pipeline (e.g. `root_path/stage1`, `root_path/plots` etc.).
+        desaturate: Toggle desaturation of the data. If True, the `stage1` to `navigate`
+            steps will be run for different numbers of groups, which are then combined
+            in the `desaturate` step to produce a desaturated data cube. If False, the
+            `reduction` step will be run only once, with the full number of groups, and
+            the `desaturate` step will be skipped (i.e. going straight to the despike
+            step).
+        parallel: Fraction of CPU cores to use when multiprocessing. Set to 0 to run
+            serially, 1 to use all cores, 0.5 to use half of the cores, etc.
+        groups_to_use: List of groups to reduce and use for desaturating the data. If
+            this is `None` (the default), then all available groups will be used. If
+            `desaturate` is False, then this argument will be ignored. The data with all
+            groups will always be included.
+        background_path: Path to directory containing background data. For example, if
+            your `root_path` is `/data/uranus/lon1`, the `background_path` may
+            be `/data/uranus/background`. Note that background subtraction will
+            require the background data to be already reduced. If no `background_path`
+            is specified (the default), then no background subtraction will be
+            performed.
+        basic_navigation: Toggle between basic or full navigation. If True, then only
+            RA and Dec navigation backplanes are generated (e.g. useful for small
+            bodies). If False (the default), then full navigation is performed,
+            generating a full set of coordinate backplanes (lon/lat, illumination
+            angles etc.). Using basic navigation automatically skips the animation step.
+        skip_steps: List of steps to skip. Defaults to None. See `STEPS` above for a
+            list of valid steps. This is mainly useful if you are re-running part of the
+            pipeline.
+        start_step: Convenience argument to add all steps before `start_step` to
+            `skip_steps`.
+        end_step: Convenience argument to add all steps after `end_step` to
+            `skip_steps`.
+
+        stage1_kwargs, stage2_kwargs, stage3_kwargs, desaturate_kwargs,
+        navigate_kwargs, despike_kwargs, background_kwargs, plot_kwargs, animate_kwargs:
+            Dictionaries of arguments passed to the corresponding functions for each
+            step of the pipeline. These can therefore be used to override the default
+            values for each step. See the documentation for each function for details on
+            the arguments. See the constants (e.g. DEFAULT_STAGE1_KWARGS) above for the
+            default values.
+    """
+    # Process args
+    parallel_kwargs = dict(
+        parallel_frac=parallel,
+        timeout=60 * 60,
+    ) | (parallel_kwargs or {})
+    reduction_parallel_kwargs = (
+        parallel_kwargs
+        | dict(
+            start_delay=10,
+            parallel_job_kw=dict(
+                caught_error_wait_time=15,
+                caught_error_wait_time_frac=1,
+                caught_error_wait_time_max=600,
+            ),
+        )
+        | (reduction_parallel_kwargs or {})
+    )
+
+    # Process skip steps
+    if skip_steps is None:
+        skip_steps = []
+    for s in skip_steps:
+        if s not in STEPS:
+            raise ValueError(f'Invalid skip step: {s!r} (valid steps: {STEPS})')
+    skip_steps = set(skip_steps)
+    if start_step is not None:
+        if start_step not in STEPS:
+            raise ValueError(
+                f'Invalid start step: {start_step!r} (valid steps: {STEPS})'
+            )
+        skip_steps.update(STEPS[: STEPS.index(start_step)])
+    if end_step is not None:
+        if end_step not in STEPS:
+            raise ValueError(f'Invalid end step: {end_step!r} (valid steps: {STEPS})')
+        skip_steps.update(STEPS[STEPS.index(end_step) + 1 :])
+    if basic_navigation:
+        skip_steps.add('animate')
+
+    # Standardise file paths
+    root_path = os.path.expandvars(os.path.expanduser(root_path))
+    if background_path is not None:
+        background_path = os.path.expandvars(os.path.expanduser(background_path))
+
+    # Print info
+    log('Running NIRSpec pipeline')
+    log(f'Root path: {root_path!r}', time=False)
+    if skip_steps:
+        log(
+            f'Skipping steps: {", ".join([repr(s) for s in STEPS if s in skip_steps])}',
+            time=False,
+        )
+    else:
+        log('Running all pipeline steps', time=False)
+    log(f'Desaturate: {desaturate!r}', time=False)
+    if groups_to_use:
+        log(f'Groups to keep: {groups_to_use!r}', time=False)
+    if basic_navigation:
+        log(f'Basic navigation: {basic_navigation!r}', time=False)
+    print()
+
+    # Run pipeline steps...
+    if desaturate and 'remove_groups' not in skip_steps:
+        run_remove_groups(root_path, groups_to_use)
+
+    # Create list of paths to reduce (both 'main' dataset and reduced groups)
+    group_root_paths = get_group_root_paths(root_path, desaturate, groups_to_use)
+
+    if 'stage1' not in skip_steps:
+        run_stage1(group_root_paths, stage1_kwargs, reduction_parallel_kwargs)
+
+    if 'stage2' not in skip_steps:
+        run_stage2(group_root_paths, stage2_kwargs, reduction_parallel_kwargs)
+
+    if 'stage3' not in skip_steps:
+        run_stage3(group_root_paths, stage3_kwargs, reduction_parallel_kwargs)
+
+    if 'navigate' not in skip_steps:
+        run_navigate(group_root_paths, basic_navigation, navigate_kwargs)
+
+    if desaturate and 'desaturate' not in skip_steps:
+        run_desaturate(root_path, group_root_paths, desaturate_kwargs, parallel_kwargs)
+
+    if 'despike' not in skip_steps:
+        run_despike(
+            root_path,
+            despike_kwargs,
+            parallel_kwargs,
+            input_stage='stage3_desaturated' if desaturate else 'stage3',
+        )
+
+    if background_path is not None and 'background' not in skip_steps:
+        run_background(root_path, background_path, background_kwargs)
+
+    if 'plot' not in skip_steps:
+        run_plot(group_root_paths, plot_kwargs, parallel_kwargs)
+
+    if 'animate' not in skip_steps:
+        run_animate(root_path, animate_kwargs, parallel_kwargs)
+
+    log('NIRSpec pipeline completed with')
+    log(f'Root path: {root_path!r}', time=False)
+    log(f'Desaturate: {desaturate!r}', time=False)
+    if skip_steps:
+        log(
+            f'Skipped steps: {", ".join([repr(s) for s in STEPS if s in skip_steps])}',
+            time=False,
+        )
+    log('ALL DONE')
+
+
+# remove groups
+def run_remove_groups(root_path: str, groups_to_use: list[int] | None = None) -> None:
+    log('Removing groups')
+    paths_in = sorted(glob.glob(os.path.join(root_path, 'stage0', '*_uncal.fits')))
+    log(f'Processing {len(paths_in)} files...', time=False)
+    for p in tqdm.tqdm(paths_in, desc='remove_groups'):
+        remove_groups.remove_groups_from_file(p, groups_to_use)
+    log('Remove groups step complete\n')
+
+
+def get_group_root_paths(
+    root_path: str, desaturate: bool, groups_to_use: list[int] | None = None
+) -> list[str]:
+    group_root_paths = [root_path]
+    if desaturate:
+        # If desaturating, we also need to reduce the data with fewer groups
+        # This list is sorted such that the number of groups is decreasing (so that the
+        # desaturation works correctly)
+        reduced_group_root_paths = sorted(
+            glob.glob(os.path.join(root_path, 'groups', '*_groups')),
+            reverse=True,
+            key=lambda _p: int(os.path.basename(_p).split('_')[0]),
+        )
+        if groups_to_use is not None:
+            reduced_group_root_paths = [
+                _p
+                for _p in reduced_group_root_paths
+                if int(os.path.basename(_p).split('_')[0]) in groups_to_use
+            ]
+        group_root_paths.extend(reduced_group_root_paths)
+    return group_root_paths
+
+
+# stage1
+def run_stage1(
+    group_root_paths: list[str],
+    stage1_kwargs: dict[str, Any] | None = None,
+    reduction_parallel_kwargs: dict[str, Any] | None = None,
+):
+    log('Running reduction stage 1')
+    kwargs = DEFAULT_STAGE1_KWARGS | (stage1_kwargs or {})
+    log(f'Arguments: {kwargs!r}', time=False)
+    for root_path in group_root_paths:
+        if len(group_root_paths) > 1:
+            log(f'Running reduction stage 1 for {root_path!r}')
+        paths_in = sorted(glob.glob(os.path.join(root_path, 'stage0', '*.fits')))
+        output_dir = os.path.join(root_path, 'stage1')
+        args_list = [(p, output_dir, kwargs) for p in paths_in]
+        log(f'Output directory: {output_dir!r}', time=False)
+        log(f'Processing {len(args_list)} files...', time=False)
+        check_path(output_dir)
+        runmany(
+            reduction_detector1_fn,
+            args_list,
+            desc='stage1',
+            **reduction_parallel_kwargs or {},
+        )
+    log('Reduction stage 1 step complete\n')
+
+
+def reduction_detector1_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+    path_in, output_dir, kwargs = args
+    Detector1Pipeline.call(path_in, output_dir=output_dir, save_results=True, **kwargs)
+
+
+# stage2
+def run_stage2(
+    group_root_paths: list[str],
+    stage2_kwargs: dict[str, Any] | None = None,
+    reduction_parallel_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running reduction stage 2')
+    kwargs = DEFAULT_STAGE2_KWARGS | (stage2_kwargs or {})
+    log(f'Arguments: {kwargs!r}', time=False)
+    for root_path in group_root_paths:
+        if len(group_root_paths) > 1:
+            log(f'Running reduction stage 2 for {root_path!r}')
+        paths_in = sorted(glob.glob(os.path.join(root_path, 'stage1', '*rate.fits')))
+        output_dir = os.path.join(root_path, 'stage2')
+        args_list = [(p, output_dir, kwargs) for p in paths_in]
+        log(f'Output directory: {output_dir!r}', time=False)
+        log(f'Processing {len(args_list)} files...', time=False)
+        check_path(output_dir)
+        runmany(
+            reduction_spec2_fn,
+            args_list,
+            desc='stage2',
+            **reduction_parallel_kwargs or {},
+        )
+    log('Reduction stage 2 step complete\n')
+
+
+def reduction_spec2_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+    path_in, output_dir, kwargs = args
+    try:
+        Spec2Pipeline.call(path_in, output_dir=output_dir, save_results=True, **kwargs)
+    except NoDataOnDetectorError:
+        log(f'No data on detector for {path_in!r}, skipping')
+
+
+# stage3
+def run_stage3(
+    group_root_paths: list[str],
+    stage3_kwargs: dict[str, Any] | None = None,
+    reduction_parallel_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running reduction stage 3')
+    kwargs = DEFAULT_STAGE3_KWARGS | (stage3_kwargs or {})
+    log(f'Arguments: {kwargs!r}', time=False)
+
+    for root_path in group_root_paths:
+        if len(group_root_paths) > 1:
+            log(f'Running reduction stage 3 for {root_path!r}')
+
+        grouped_files = group_stage2_files_for_stage3(root_path)
+
+        # Only need to include the tile in prodname if it is needed to avoid filename
+        # collisions for observations which use mosaicing. Most observations just have a
+        # single tile per datset, so we can just use the standard prodname in this case
+        keys_with_tiles = set(grouped_files.keys())
+        keys_without_tiles = set(
+            (dither, filter_, grating)
+            for dither, tile, filter_, grating in keys_with_tiles
+        )
+        include_tile_in_prodname = len(keys_with_tiles) != len(keys_without_tiles)
+
+        asn_paths_list: list[tuple[str, str]] = []
+        for (dither, tile, filter_, grating), paths in grouped_files.items():
+            dirname = 'combined' if dither is None else f'd{dither}'
+            output_dir = os.path.join(root_path, 'stage3', dirname)
+            check_path(output_dir)
+            asn_path = os.path.join(
+                output_dir, f'l3asn-{tile}_{filter_}_{grating}_dither-{dirname}.json'
+            )
+            write_asn_for_stage3(
+                paths,
+                asn_path,
+                prodname='Level3' + (f'_{tile}' if include_tile_in_prodname else ''),
+            )
+            asn_paths_list.append((asn_path, output_dir))
+        args_list = [
+            (p, output_dir, kwargs) for p, output_dir in sorted(asn_paths_list)
+        ]
+        log(f'Processing {len(args_list)} files...', time=False)
+        runmany(
+            reduction_spec3_fn,
+            args_list,
+            desc='stage3',
+            **reduction_parallel_kwargs or {},
+        )
+    log('Reduction stage 3 step complete\n')
+
+
+def group_stage2_files_for_stage3(
+    root_path: str,
+) -> dict[tuple[int | None, str, str, str], list[str]]:
+    out: dict[tuple[int | None, str, str, str], list[str]] = {}
+    paths_in = sorted(glob.glob(os.path.join(root_path, 'stage2', '*_cal.fits')))
+    for p in paths_in:
+        with fits.open(p) as hdul:
+            hdr = hdul[0].header  #  type: ignore
+        dither = int(hdr['PATT_NUM'])
+        tile = hdr['ACT_ID']
+        filter_ = hdr['FILTER']
+        grating = hdr['GRATING']
+
+        # Keep dithers separate
+        k = (dither, tile, filter_, grating)
+        out.setdefault(k, []).append(p)
+
+        # Combine dithers
+        k = (None, tile, filter_, grating)
+        out.setdefault(k, []).append(p)
+    return out
+
+
+def write_asn_for_stage3(
+    files: list[str], asnfile: str, prodname: str, **kwargs
+) -> str:
+    asn = asn_from_list(files, rule=DMS_Level3_Base, product_name=prodname)
+    if 'bg' in kwargs:
+        for bgfile in kwargs['bg']:
+            asn['products'][0]['members'].append(
+                {'expname': bgfile, 'exptype': 'background'}
+            )
+    _, serialized = asn.dump()
+    with open(asnfile, 'w', encoding='utf-8') as outfile:
+        outfile.write(serialized)
+    return asnfile
+
+def reduction_spec3_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+    asn_path, output_dir, kwargs = args
+    Spec3Pipeline.call(
+        asn_path,
+        output_dir=output_dir,
+        save_results=True,
+        **kwargs,
+    )
+
+
+# navigation
+def run_navigate(
+    group_root_paths: list[str],
+    basic_navigation: bool = False,
+    navigate_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running navigate')
+    kwargs = DEFAULT_NAVIGATE_KWARGS | (navigate_kwargs or {})
+    log(f'Basic navigation: {basic_navigation!r}', time=False)
+    log(f'Arguments: {kwargs!r}', time=False)
+    navigate_jwst_observations.load_kernels()
+    for root_path in group_root_paths:
+        if len(group_root_paths) > 1:
+            log(f'Running navigation for {root_path!r}')
+        paths_in = sorted(
+            glob.glob(os.path.join(root_path, 'stage3', '*', '*_s3d.fits'))
+        )
+        navigate_jwst_observations.navigate_multiple(
+            *paths_in, basic=basic_navigation, **kwargs
+        )
+    log('Navigate step complete\n')
+
+
+# desaturate
+def run_desaturate(
+    root_path: str,
+    group_root_paths: list[str],
+    desaturate_kwargs: dict[str, Any] | None = None,
+    parallel_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running desaturate')
+    kwargs = DEFAULT_DESATURATE_KWARGS | (desaturate_kwargs or {})
+    parallel_kwargs = parallel_kwargs or {}
+    log(f'Arguments: {kwargs!r}', time=False)
+
+    paths_dict: dict[str, list[str]] = {}
+    for rp in group_root_paths:
+        paths_in = sorted(glob.glob(os.path.join(rp, 'stage3', '*_nav', '*_nav.fits')))
+        for p_in in paths_in:
+            relpath = os.path.relpath(p_in, rp)
+            relpath = replace_path_part(
+                relpath, -3, 'stage3_desaturated', check_old='stage3'
+            )
+            p_out = os.path.join(root_path, relpath)
+            paths_dict.setdefault(p_out, []).append(p_in)
+    args_list = [(paths_in, p_out, kwargs) for p_out, paths_in in paths_dict.items()]
+    log(f'Processing {len(args_list)} output files...', time=False)
+    runmany(desaturate_fn, args_list, desc='desaturate', **parallel_kwargs)
+    log('Desaturate step complete\n')
+
+
+def desaturate_fn(args: tuple[list[str], str, dict[str, Any]]) -> None:
+    paths_in, path_out, kwargs = args
+    desaturate_data.replace_saturated(paths_in, path_out, **kwargs)
+
+
+# despike
+def run_despike(
+    root_path: str,
+    despike_kwargs: dict[str, Any] | None = None,
+    parallel_kwargs: dict[str, Any] | None = None,
+    input_stage: str = 'stage3',
+) -> None:
+    log('Running despike')
+    paths_in = sorted(
+        glob.glob(os.path.join(root_path, input_stage, '*_nav', '*_nav.fits'))
+    )
+    paths_out = [
+        replace_path_part(p, -3, 'stage4_despike', check_old=input_stage)
+        for p in paths_in
+    ]
+    parallel_kwargs = parallel_kwargs or {}
+    kwargs = DEFAULT_DESPIKE_KWARGS | (despike_kwargs or {})
+    if parallel_kwargs.get('parallel_frac', False):
+        kwargs.setdefault('progress_bar', False)
+    args_list = [(p_in, p_out, kwargs) for p_in, p_out in zip(paths_in, paths_out)]
+    log(f'Arguments: {kwargs!r}', time=False)
+    log(f'Processing {len(args_list)} files...', time=False)
+    runmany(despike_fn, args_list, desc='despike', **parallel_kwargs)
+    log('Despike step complete\n')
+
+
+def despike_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+    p_in, p_out, kwargs = args
+    despike_data.despike_cube(p_in, p_out, **kwargs)
+
+
+# background
+def run_background(
+    root_path: str,
+    background_path: str,
+    background_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running background')
+    kwargs = DEFAULT_BACKGROUND_KWARGS | (background_kwargs or {})
+    log(f'Arguments: {kwargs!r}', time=False)
+
+    paths_in = sorted(
+        glob.glob(os.path.join(root_path, 'stage4_despike', 'd*_nav', '*_nav.fits'))
+    )
+    log(f'Processing {len(paths_in)} input files...', time=False)
+    for p_in in tqdm.tqdm(paths_in, desc='background'):
+        p_out = replace_path_part(
+            p_in, -3, 'stage5_background', check_old='stage4_despike'
+        )
+        with fits.open(p_in) as hdul:
+            hdr = hdul['PRIMARY'].header  #  type: ignore
+        p_background = os.path.join(
+            background_path,
+            'stage4_despike',
+            'd{dither}_nav',
+            'Level3_{grating}-{filter}_s3d_nav.fits',
+        ).format(
+            grating=hdr['GRATING'].lower(),
+            filter=hdr['FILTER'].lower(),
+            dither='1',
+        )
+        background_subtraction.subtract_background(p_in, p_out, p_background, **kwargs)
+    log('Background step complete\n')
+
+
+# plot
+def run_plot(
+    group_root_paths: list[str],
+    plot_kwargs: dict[str, Any] | None = None,
+    parallel_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running plot')
+    kwargs = DEFAULT_PLOT_KWARGS | (plot_kwargs or {})
+    parallel_kwargs = parallel_kwargs or {}
+    log(f'Arguments: {kwargs!r}', time=False)
+    for root_path in group_root_paths:
+        if len(group_root_paths) > 1:
+            log(f'Generating quick look plots for {root_path!r}')
+        for stage in reversed(DATA_STAGES):
+            log(f'Generating quick look plots for stage {stage!r}')
+            paths_in = sorted(
+                glob.glob(os.path.join(root_path, stage, '*_nav', '*_nav.fits'))
+            )
+            paths_out = [
+                replace_path_part(p, -3, os.path.join('plots', stage), check_old=stage)
+                for p in paths_in
+            ]
+            paths_out = [
+                replace_path_suffix(p, '.png', check_old='.fits') for p in paths_out
+            ]
+            args_list = [
+                (p_in, p_out, kwargs) for p_in, p_out in zip(paths_in, paths_out)
+            ]
+            log(f'Processing {len(args_list)} files...', time=False)
+            runmany(plot_fn, args_list, desc='plot', **parallel_kwargs)
+    log('Plot step complete\n')
+
+
+def plot_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+    p_in, p_out, kwargs = args
+    jwst_summary_plots.make_summary_plot(p_in, p_out, **kwargs)
+
+
+# animate
+def run_animate(
+    root_path: str,
+    animate_kwargs: dict[str, Any] | None = None,
+    parallel_kwargs: dict[str, Any] | None = None,
+) -> None:
+    log('Running animate')
+    kwargs = DEFAULT_ANIMATE_KWARGS | (animate_kwargs or {})
+    parallel_kwargs = parallel_kwargs or {}
+    if parallel_kwargs.get('parallel_frac', False):
+        kwargs.setdefault('progress_bar', False)
+    log(f'Arguments: {kwargs!r}', time=False)
+    for stage in reversed(DATA_STAGES):
+        log(f'Generating quick look animations for stage {stage!r}')
+        paths_in = sorted(
+            glob.glob(os.path.join(root_path, stage, 'd*_nav', '*_nav.fits'))
+        )
+        paths_dict: dict[str, list[str]] = {}
+        for p_in in paths_in:
+            filename = os.path.basename(
+                replace_path_suffix(p_in, '.mp4', check_old='.fits')
+            )
+            p_out = os.path.join(root_path, 'animation', stage, filename)
+            paths_dict.setdefault(p_out, []).append(p_in)
+        args_list = [
+            (paths_in, p_out, kwargs) for p_out, paths_in in paths_dict.items()
+        ]
+        log(f'Processing {len(args_list)} files...', time=False)
+        runmany(animation_fn, args_list, desc='animate', **parallel_kwargs)
+    log('Animate step complete\n')
+
+
+def animation_fn(args: tuple[list[str], str, dict[str, Any]]) -> None:
+    paths_in, p_out, kwargs = args
+    jwst_summary_animation.make_animation(paths_in, p_out, **kwargs)
+
+
+# utils
+def replace_path_part(
+    path: str, idx: int, new: str, *, check_old: str | None = None
+) -> str:
+    """
+    Replace a part of a path with a new value.
+
+    Args:
+        path: The path to modify.
+        idx: The index of the part to replace in the directory tree.
+        new: The new value to use.
+        check_old: If not None, check that the value at the index is this value
+            before replacing it.
+
+    Returns:
+        The modified path.
+    """
+    p = pathlib.Path(path)
+    parts = list(p.parts)
+    if check_old is not None and parts[idx] != check_old:
+        raise ValueError(f'Expected {check_old!r} at index {idx} in {path!r}')
+    parts[idx] = new
+    return str(pathlib.Path(*parts))
+
+
+def replace_path_suffix(path: str, new: str, *, check_old: str | None = None) -> str:
+    """
+    Replace the suffix of a path with a new value.
+
+    Args:
+        path: The path to modify.
+        new: The new value to use.
+        check_old: If not None, check that the suffix is this value before
+            replacing it.
+
+    Returns:
+        The modified path.
+    """
+    p = pathlib.Path(path)
+    if check_old is not None and p.suffix != check_old:
+        raise ValueError(f'Expected {check_old!r} suffix in {path!r}')
+    return str(p.with_suffix(new))
+
+
+def main():
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(
+        description=(
+            'Full JWST NIRSpec IFU pipeline including the standard reduction from '
+            'stage0 to stage3, and custom pipeline steps for additional cleaning and '
+            'data visualisation. For more customisation, this script can be imported '
+            'and run in Python (see the source code for mode details).\n\n'
+            'The following steps are run in the full pipeline:' + STEP_DESCRIPTIONS
+        ),
+        epilog=CLI_EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        argument_default=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        'root_path',
+        type=str,
+        help="""Path to the directory containing the data. This directory should
+            contain a subdirectory with the stage0 data (i.e. `root_path/stage0`).
+            Additional directories will be created automatically for each step of the
+            pipeline (e.g. `root_path/stage1`, `root_path/plots` etc.).""",
+    )
+    parser.add_argument(
+        '--desaturate',
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="""Toggle desaturation of the data. If desaturation is enabled the 
+            `reduction` step will be run for different numbers of groups, which are then
+            combined in the `desaturate` step to produce a desaturated data cube. This
+            desaturation is enabled by default.
+            """,
+    )
+    parser.add_argument(
+        '--parallel',
+        nargs='?',
+        const=1,
+        type=float,
+        help="""Fraction of CPU cores to use when multiprocessing. For example, set 
+        0.5 to use half of the available cores. If unspecified, then multiprocessing 
+        will not be used and the pipeline will be run serially. If specified but no 
+        value is given, then all available cores will be used (i.e. `--parallel` is 
+        equivalent to `--parallel 1`).""",
+    )
+    parser.add_argument(
+        '--groups_to_use',
+        type=str,
+        help="""Comma-separated list of groups to keep. For example, `1,2,3,4` will
+            keep the first four groups. If unspecified, all groups will be kept.""",
+    )
+    parser.add_argument(
+        '--background_path',
+        type=str,
+        help="""Path to directory containing background data. For example, if
+            your `root_path` is `/data/uranus/lon1`, the `background_path` may
+            be `/data/uranus/background`. Note that background subtraction will
+            require the background data to be already reduced. If no `background_path`
+            is specified (the default), then no background subtraction will be 
+            performed.""",
+    )
+    parser.add_argument(
+        '--basic_navigation',
+        action='store_true',
+        help="""Use basic navigation, and only save RA and Dec backplanes (e.g. useful
+            for small bodies). By default, full navigation is performed, generating a
+            full set of coordinate backplanes (lon/lat, illumination angles etc.). Using
+            basic navigation automatically skips the navigation step.""",
+    )
+    parser.add_argument(
+        '--skip_steps',
+        nargs='+',
+        type=str,
+        help="""List of steps to skip. This is generally only useful if you are
+            re-running part of the pipeline. Multiple steps can be passed as a
+            space-separated list. For example, `--skip_steps flat despike`.""",
+    )
+    parser.add_argument(
+        '--start_step',
+        type=str,
+        help="""Convenience argument to add all steps before `start_step` to 
+            `skip_steps`.""",
+    )
+    parser.add_argument(
+        '--end_step',
+        type=str,
+        help="""Convenience argument to add all steps steps after `end_step` to 
+            `skip_steps`.""",
+    )
+    parser.add_argument(
+        '--kwargs',
+        type=str,
+        help="""JSON string containing keyword arguments to pass to individual pipeline
+            steps. For example, 
+            `--kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "animation": {"radius_factor": 2.5}}'` 
+            will pass the custom arguments to the stage3 and animation steps.
+            """,
+    )
+    args = vars(parser.parse_args())
+    json_kwargs = args.pop('kwargs', None)
+    if json_kwargs:
+        json_kwargs = json.loads(json_kwargs)
+        for k, v in json_kwargs.items():
+            if not k.endswith('_kwargs'):
+                k = k + '_kwargs'
+            args[k] = v
+    if 'groups_to_use' in args:
+        args['groups_to_use'] = [int(g) for g in args['groups_to_use'].split(',')]
+    run_pipeline(**args)
+
+
+if __name__ == '__main__':
+    main()

--- a/nirspec_pipeline_old.py
+++ b/nirspec_pipeline_old.py
@@ -659,6 +659,7 @@ def write_asn_for_stage3(
         outfile.write(serialized)
     return asnfile
 
+
 def reduction_spec3_fn(args: tuple[str, str, dict[str, Any]]) -> None:
     asn_path, output_dir, kwargs = args
     Spec3Pipeline.call(

--- a/parallel_tools.py
+++ b/parallel_tools.py
@@ -56,6 +56,7 @@ def runmany(
         num_processors = get_max_processors(parallel_frac)
 
     if num_processors == 1:
+        log(f'Processing {len(args_list)} jobs serially...')
         for a in tqdm.tqdm(args_list, **tqdm_kw):
             function(a)
     else:

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,422 @@
+import argparse
+import datetime
+import glob
+import json
+import os
+import pathlib
+from collections.abc import Collection
+from typing import Any, Generator, Literal, TypeAlias, overload
+
+import tqdm
+from astropy.io import fits
+from jwst.assign_wcs.util import NoDataOnDetectorError
+from jwst.associations.asn_from_list import asn_from_list
+from jwst.associations.lib.rules_level3_base import DMS_Level3_Base
+from jwst.pipeline import Detector1Pipeline, Spec2Pipeline, Spec3Pipeline
+from jwst.residual_fringe import ResidualFringeStep
+
+import background_subtraction
+import desaturate_data
+import despike_data
+import jwst_summary_animation
+import jwst_summary_plots
+import navigate_jwst_observations
+import remove_groups
+from parallel_tools import runmany
+from tools import check_path
+
+Step: TypeAlias = Literal[
+    'remove_groups',
+    'stage1',
+    'stage2',
+    'defringe',
+    'stage3',
+    'navigate',
+    'desaturate',
+    'flat',
+    'despike',
+    'background',
+    'plot',
+    'animate',
+]
+
+
+class Pipeline:
+    STEPS: tuple[Step, ...] = ()  # override this in subclasses
+    DEFAULT_KWARGS: dict[Step, dict[str, Any]] = {}  # override this in subclasses
+    DATA_STAGES: tuple[str, ...] = ()  # override this in subclasses
+
+    def __init__(
+        self,
+        root_path: str,
+        *,
+        parallel: float | bool = False,
+        desaturate: bool = True,
+        groups_to_use: list[int] | None = None,
+        background_path: str | None = None,
+        basic_navigation: bool = False,
+        step_kwargs: dict[Step, dict[str, Any]] | None = None,
+        parallel_kwargs: dict[str, Any] | None = None,
+        reduction_parallel_kwargs: dict[str, Any] | None = None,
+    ):
+        # TODO docstring
+        parallel_kwargs = dict(
+            parallel_frac=parallel,
+            timeout=60 * 60,
+        ) | (parallel_kwargs or {})
+        reduction_parallel_kwargs = (
+            parallel_kwargs
+            | dict(
+                start_delay=10,
+                parallel_job_kw=dict(
+                    caught_error_wait_time=15,
+                    caught_error_wait_time_frac=1,
+                    caught_error_wait_time_max=600,
+                ),
+            )
+            | (reduction_parallel_kwargs or {})
+        )
+        self.parallel_kwargs = parallel_kwargs
+        self.reduction_parallel_kwargs = reduction_parallel_kwargs
+        self.step_kwargs = step_kwargs or {}
+        self.root_path = self.standardise_path(root_path)
+        self.desaturate = desaturate
+        self.groups_to_use = groups_to_use
+        self.background_path = self.standardise_path(background_path)
+        self.basic_navigation = basic_navigation
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}({self.root_path!r})'
+
+    @property
+    def instrument(self) -> str:
+        raise NotImplementedError
+
+    # Pipeline running
+    def run(
+        self,
+        *,
+        skip_steps: Collection[Step] | None = None,
+        start_step: Step | None = None,
+        end_step: Step | None = None,
+    ):
+        # TODO docstring
+        skip_steps = self.process_skip_steps(skip_steps, start_step, end_step)
+        self.log(f'Running {self.instrument} pipeline')
+        self.print_reduction_info(skip_steps)
+        print()
+        for step in self.STEPS:
+            if step in skip_steps:
+                continue
+            self.run_step(step)
+
+        self.log(f'{self.instrument} pipeline completed with')
+        self.print_reduction_info(skip_steps)
+        self.log('ALL DONE')
+
+    def run_step(self, step: Step) -> None:
+        """Run pipeline step"""
+        self.log(f'Running {step} step')
+        kwargs = self.DEFAULT_KWARGS.get(step, {}) | self.step_kwargs.get(step, {})
+        if kwargs:
+            self.log(f'Arguments: {kwargs!r}', time=False)
+        skipped = getattr(self, f'run_{step}')(kwargs)
+        if not skipped:
+            self.log(f'{step} step completed')
+
+    def process_skip_steps(
+        self,
+        skip_steps: Collection[Step] | None,
+        start_step: Step | None,
+        end_step: Step | None,
+    ) -> set[Step]:
+        """
+        Process the various step arguments to create a comprehensive set of steps to
+        skip.
+        """
+        if skip_steps is None:
+            skip_steps = []
+        for s in skip_steps:
+            if s not in self.STEPS:
+                raise ValueError(
+                    f'Invalid skip step: {s!r} (valid steps: {self.STEPS})'
+                )
+        skip_steps = set(skip_steps)
+        if start_step is not None:
+            if start_step not in self.STEPS:
+                raise ValueError(
+                    f'Invalid start step: {start_step!r} (valid steps: {self.STEPS})'
+                )
+            skip_steps.update(self.STEPS[: self.STEPS.index(start_step)])
+        if end_step is not None:
+            if end_step not in self.STEPS:
+                raise ValueError(
+                    f'Invalid end step: {end_step!r} (valid steps: {self.STEPS})'
+                )
+            skip_steps.update(self.STEPS[self.STEPS.index(end_step) + 1 :])
+        if self.basic_navigation:
+            skip_steps.add('animate')
+        return skip_steps
+
+    def print_reduction_info(self, skip_steps: set[Step]) -> None:
+        """Print information about the current reduction run."""
+        self.log(f'Root path: {self.root_path!r}', time=False)
+        if skip_steps:
+            self.log(
+                f'Skipping steps: {", ".join([repr(s) for s in self.STEPS if s in skip_steps])}',
+                time=False,
+            )
+        else:
+            self.log('Running all pipeline steps', time=False)
+        self.log(f'Desaturate: {self.desaturate!r}', time=False)
+        if self.groups_to_use:
+            self.log(f'Groups to keep: {self.groups_to_use!r}', time=False)
+        if self.basic_navigation:
+            self.log(f'Basic navigation: {self.basic_navigation!r}', time=False)
+
+    # Utility methods
+    @staticmethod
+    @overload
+    def standardise_path(path: str) -> str:
+        ...
+
+    @staticmethod
+    @overload
+    def standardise_path(path: None) -> None:
+        ...
+
+    @staticmethod
+    def standardise_path(path: str | None) -> str | None:
+        """Standardise a path by expanding environment variables and user."""
+        if path is None:
+            return None
+        return os.path.expandvars(os.path.expanduser(path))
+
+    @staticmethod
+    def log(*messages: Any, time: bool = True) -> None:
+        """
+        Print a message with a timestamp.
+
+        Args:
+            *messages: Messages passed to `print()`.
+            time: Toggle showing the timestamp.
+        """
+        prefix = datetime.datetime.now().strftime('%H:%M:%S') if time else ' ' * 8
+        print(prefix, *messages, flush=True)
+
+    def get_paths(self, *path_parts: str) -> list[str]:
+        """Get a list of paths matching the given path parts."""
+        return sorted(glob.glob(os.path.join(self.root_path, *path_parts)))
+
+    @property
+    def group_root_paths(self) -> list[str]:
+        group_root_paths = [self.root_path]
+        if self.desaturate:
+            # If desaturating, we also need to reduce the data with fewer groups
+            # This list is sorted such that the number of groups is decreasing (so that the
+            # desaturation works correctly)
+            reduced_group_root_paths = sorted(
+                glob.glob(os.path.join(self.root_path, 'groups', '*_groups')),
+                reverse=True,
+                key=lambda _p: int(os.path.basename(_p).split('_')[0]),
+            )
+            if self.groups_to_use is not None:
+                reduced_group_root_paths = [
+                    _p
+                    for _p in reduced_group_root_paths
+                    if int(os.path.basename(_p).split('_')[0]) in self.groups_to_use
+                ]
+            group_root_paths.extend(reduced_group_root_paths)
+        return group_root_paths
+
+    def iterate_group_root_paths(self) -> Generator[str, Any, None]:
+        group_root_paths = self.group_root_paths
+        for idx, root_path in enumerate(group_root_paths):
+            if len(group_root_paths) > 1:
+                self.log(
+                    f'Processing group directory {idx+1}/{len(group_root_paths)} ({root_path!r})'
+                )
+            yield root_path
+
+    @property
+    def data_variants(self) -> list[str]:
+        # TODO some sort of list of variants of the data e.g.
+        # '', _fringe, _bg, _bg_fringe
+        pass
+
+    def iterate_data_variants(self) -> Generator[str, Any, None]:
+        pass
+
+    # Pipeline steps
+    def run_remove_groups(self, kwargs: dict[str, Any]) -> None:
+        paths_in = self.get_paths('stage0', '*_uncal.fits')
+        self.log(f'Processing {len(paths_in)} files...', time=False)
+        for p in tqdm.tqdm(paths_in, desc='remove_groups'):
+            remove_groups.remove_groups_from_file(p, self.groups_to_use)
+
+    def run_stage1(self, kwargs: dict[str, Any]) -> None:
+        for root_path in self.iterate_group_root_paths():
+            paths_in = self.get_paths('stage0', '*.fits')
+            output_dir = os.path.join(root_path, 'stage1')
+            args_list = [(p, output_dir, kwargs) for p in paths_in]
+            self.log(f'Output directory: {output_dir!r}', time=False)
+            self.log(f'Processing {len(args_list)} files...', time=False)
+            check_path(output_dir)
+            runmany(
+                self.reduction_detector1_fn,
+                args_list,
+                desc='stage1',
+                **self.reduction_parallel_kwargs,
+            )
+
+    @staticmethod
+    def reduction_detector1_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+        path_in, output_dir, kwargs = args
+        Detector1Pipeline.call(
+            path_in, output_dir=output_dir, save_results=True, **kwargs
+        )
+
+    def run_stage2(self, kwargs: dict[str, Any]) -> None:
+        for root_path in self.iterate_group_root_paths():
+            paths_in = self.get_paths('stage1', '*rate.fits')
+            output_dir = os.path.join(root_path, 'stage2')
+            args_list = [(p, output_dir, kwargs) for p in paths_in]
+            self.log(f'Output directory: {output_dir!r}', time=False)
+            self.log(f'Processing {len(args_list)} files...', time=False)
+            check_path(output_dir)
+            runmany(
+                self.reduction_spec2_fn,
+                args_list,
+                desc='stage2',
+                **self.reduction_parallel_kwargs,
+            )
+
+    @staticmethod
+    def reduction_spec2_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+        path_in, output_dir, kwargs = args
+        Spec2Pipeline.call(path_in, output_dir=output_dir, save_results=True, **kwargs)
+
+
+class MIRIPipeline(Pipeline):
+    STEPS = (
+        'remove_groups',
+        'stage1',
+        'stage2',
+        'defringe',
+        'stage3',
+        'navigate',
+        'desaturate',
+        'flat',
+        'despike',
+        'background',
+        'plot',
+        'animate',
+    )
+    DEFAULT_KWARGS = {
+        'stage2': {
+            'steps': {'cube_build': {'skip': True}, 'extract_1d': {'skip': True}}
+        },
+        'defringe': {'skip': False},
+        'stage3': {
+            'steps': {
+                'master_background': {'skip': True},
+                'extract_1d': {'skip': True},
+                'cube_build': {'output_type': 'band', 'coord_system': 'ifualign'},
+            }
+        },
+    }
+    DATA_STAGES = (
+        'stage3',
+        'stage3_desaturated',
+        'stage4_flat',
+        'stage5_despike',
+        'stage6_background',
+    )
+
+    @property
+    def instrument(self) -> str:
+        return 'MIRI'
+
+    @staticmethod
+    def reduction_detector1_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+        path_in, output_dir, kwargs = args
+        kwargs = kwargs.copy()
+        with fits.open(path_in) as hdul:
+            ngroups = hdul['PRIMARY'].header['NGROUPS']  # type: ignore
+        if ngroups <= 3:
+            kwargs['steps'] = kwargs.get('steps', {}) | {
+                'firstframe': {'skip': True},
+                'lastframe': {'skip': True},
+                'rscd': {'skip': True},
+                'jump': {'skip': True},
+            }
+        return super().reduction_detector1_fn((path_in, output_dir, kwargs))
+
+    def run_defringe(self, kwargs: dict[str, Any]) -> None:
+        for root_path in self.iterate_group_root_paths():
+            paths_in = self.get_paths('stage2', '*cal.fits')
+            output_dir = os.path.join(root_path, 'stage2')
+            args_list = [(p, output_dir, kwargs) for p in paths_in]
+            self.log(f'Output directory: {output_dir!r}', time=False)
+            self.log(f'Processing {len(args_list)} files...', time=False)
+            check_path(output_dir)
+            runmany(
+                self.defringe_fn,
+                args_list,
+                desc='defringe',
+                **self.reduction_parallel_kwargs,
+            )
+
+    @staticmethod
+    def defringe_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+        path_in, output_dir, kwargs = args
+        ResidualFringeStep.call(
+            path_in, output_dir=output_dir, save_results=True, **kwargs
+        )
+
+
+class NIRSpecPipeline(Pipeline):
+    STEPS = (
+        'remove_groups',
+        'stage1',
+        'stage2',
+        'stage3',
+        'navigate',
+        'desaturate',
+        'despike',
+        'background',
+        'plot',
+        'animate',
+    )
+    DEFAULT_KWARGS = {
+        'stage2': {
+            'steps': {
+                'cube_build': {'coord_system': 'ifualign'},
+                'extract_1d': {'skip': True},
+            }
+        },
+        'stage3': {
+            'steps': {
+                'cube_build': {'coord_system': 'ifualign'},
+                'extract_1d': {'skip': True},
+            }
+        },
+    }
+    DATA_STAGES = (
+        'stage3',
+        'stage3_desaturated',
+        'stage4_despike',
+        'stage5_background',
+    )
+
+    @property
+    def instrument(self) -> str:
+        return 'NIRSpec'
+
+    @staticmethod
+    def reduction_spec2_fn(args: tuple[str, str, dict[str, Any]]) -> None:
+        try:
+            return super().reduction_spec2_fn(args)
+        except NoDataOnDetectorError:
+            path_in, output_dir, kwargs = args
+            print(f'No data on detector for {path_in!r}, skipping')

--- a/pipeline.py
+++ b/pipeline.py
@@ -13,7 +13,6 @@ from typing import Any, Collection, Generator, Literal, Type, TypeAlias, cast, o
 
 import tqdm
 from astropy.io import fits
-from jwst.assign_wcs.util import NoDataOnDetectorError
 from jwst.associations.asn_from_list import asn_from_list
 from jwst.associations.lib.rules_level3_base import DMS_Level3_Base
 from jwst.pipeline import Detector1Pipeline, Spec2Pipeline, Spec3Pipeline
@@ -521,6 +520,7 @@ class Pipeline:
 
     # Pipeline steps -------------------------------------------------------------------
     # remove_groups
+    # pylint: disable-next=unused-argument
     def run_remove_groups(self, kwargs: dict[str, Any]) -> None:
         dir_in, dir_out = self.step_directories['remove_groups']
         paths_in = self.get_paths(dir_in, '*_uncal.fits')
@@ -865,6 +865,7 @@ class Pipeline:
         p_in, p_out, kwargs = args
         jwst_summary_plots.make_summary_plot(p_in, p_out, **kwargs)
 
+    # pylint: disable-next=unused-argument
     def get_plot_filename_prefix(self, path: str) -> str:
         """
         Get filename prefix to use for plots/animations e.g. '1A_' for MIRI.
@@ -1041,7 +1042,7 @@ class MiriPipeline(Pipeline):
 
 
 def get_pipeline_argument_parser(
-    pipeline: Type[Pipeline],
+    pipeline_class: Type[Pipeline],
     step_descriptions: str,
     cli_examples: str,
 ) -> argparse.ArgumentParser:
@@ -1052,7 +1053,7 @@ def get_pipeline_argument_parser(
     `run_pipeline(**vars(parser.parse_args()))` to run the pipeline.
     """
     suffix = step_descriptions + '\n' + cli_examples
-    name = pipeline.get_instrument()
+    name = pipeline_class.get_instrument()
     parser = argparse.ArgumentParser(
         description=(
             f'Full JWST {name} IFU pipeline including the standard reduction from '

--- a/pipeline.py
+++ b/pipeline.py
@@ -443,7 +443,7 @@ class Pipeline:
         for idx, root_path in enumerate(group_root_paths):
             if len(group_root_paths) > 1:
                 self.log(
-                    f'Processing group directory {idx+1}/{len(group_root_paths)} ({root_path!r})'
+                    f'Processing group directory {idx+1}/{len(group_root_paths)}: {root_path!r}'
                 )
             yield root_path
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -1084,6 +1084,16 @@ def get_pipeline_argument_parser(
         equivalent to `--parallel 1`).""",
     )
     parser.add_argument(
+        '--desaturate',
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="""Toggle desaturation of the data. If desaturation is enabled the 
+            `reduction` step will be run for different numbers of groups, which are then
+            combined in the `desaturate` step to produce a desaturated data cube. This
+            desaturation is enabled by default.
+            """,
+    )
+    parser.add_argument(
         '--groups_to_use',
         type=str,
         help="""Comma-separated list of groups to keep. For example, `1,2,3,4` will

--- a/pipeline.py
+++ b/pipeline.py
@@ -796,15 +796,15 @@ class Pipeline:
 
         # Group paths by their relative path to the group root path
         paths_dict: dict[str, list[str]] = {}
-        for root_path in self.iterate_group_root_paths():
+        for group_root_path in self.iterate_group_root_paths():
             paths_in = self.get_paths(
-                root_path, dir_in, '*', '*_nav.fits', filter_variants=True
+                group_root_path, dir_in, '*', '*_nav.fits', filter_variants=True
             )
             for p_in in paths_in:
                 # get file path relative to the root of the group root path
-                relpath = os.path.relpath(p_in, root_path)
+                relpath = os.path.relpath(p_in, group_root_path)
                 relpath = self.replace_path_part(relpath, -3, dir_out, old=dir_in)
-                p_out = os.path.join(root_path, relpath)
+                p_out = os.path.join(self.root_path, relpath)
                 paths_dict.setdefault(p_out, []).append(p_in)
 
         args_list = [


### PR DESCRIPTION
Refactored pipelines to put common code into `Pipeline` class which the NIRSpec and MIRI pipelines then inherit from. Significantly improves maintainability of pipelines, and ensures consistency of pipeline APIs and behaviour.

Note that directory structures produced by the updated pipelines may change slightly from previous versions. Old standalone pipeline scripts are available as `miri_pipeline_old.py` and `nirspec_pipeline_old.py` if needed.

Also added dither combination to stage3 and moved background subtraction to stage2.
