### PR TITLE
Merge kwargs as nested dictionaries to ensure default kwargs are preserved (unless specifically overwritten)

### DIFF
--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -395,7 +395,8 @@ def run_pipeline(
             arguments. For example,
             `step_kwargs={'stage3':{'outlier_detection': {'snr': '30.0 24.0', 'scale': '1.3 0.7'}}}`
             can will customise the `stage3` step. See the DEFAULT_KWARGS constant above
-            for the default values.
+            for the default values. The provided kwargs will be merged with the default
+            kwargs.
         parallel_kwargs: Dictionary of keyword arguments to customise parallel
             processing.
         reduction_parallel_kwargs: Dictionary of keyword arguments to customise parallel

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -341,7 +341,8 @@ def run_pipeline(
             arguments. For example,
             `step_kwargs={'stage3':{'outlier_detection': {'snr': '30.0 24.0', 'scale': '1.3 0.7'}}}`
             can will customise the `stage3` step. See the DEFAULT_KWARGS constant above
-            for the default values.
+            for the default values. The provided kwargs will be merged with the default
+            kwargs.
         parallel_kwargs: Dictionary of keyword arguments to customise parallel
             processing.
         reduction_parallel_kwargs: Dictionary of keyword arguments to customise parallel

--- a/tools.py
+++ b/tools.py
@@ -589,3 +589,20 @@ def make_rgb_images(
         image_data = np.clip(image_data, 0, 1)
         out.append(np.moveaxis(image_data, 0, -1))
     return out
+
+
+def merge_nested_dicts(*dicts: dict) -> dict:
+    """
+    Merge nested dictionaries.
+
+    Args:
+        dicts: Dictionaries to merge.
+    """
+    result = {}
+    for d in dicts:
+        for key, value in d.items():
+            if isinstance(value, dict):
+                result[key] = merge_nested_dicts(result.get(key, {}), value)
+            else:
+                result[key] = value
+    return result


### PR DESCRIPTION
Default kwargs are now preserved a different part of the same step is customised with the `--step-kwargs` flag.