### PR TITLE
Improvements for point source targets, better warnings and easier customisation  

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -120,8 +120,15 @@ python3 miri_pipeline.py /path/to/your/miri/data
 ```
 
 or if you are working from a different directory, you can use:
+
 ```bash
 python3 /path/to/pipelines/miri_pipeline.py /path/to/your/miri/data
+```
+
+The pipeline can be customised by calling with various arguments, for example:
+
+```bash
+python3 miri_pipeline.py /path/to/your/miri/data --parallel --desaturate --skip-steps despike --cube-build-weighting emsm
 ```
 
 For more detailed documentation, including the various customisation options, see the instructions at the top of the [`miri_pipeline.py`](https://github.com/ortk95/jwst-pipelines/blob/main/miri_pipeline.py) file or run `python3 miri_pipeline.py --help`.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ python3 nirspec_pipeline.py /path/to/your/nirspec/data
 
 For more detailed documentation, including the various customisation options, see the instructions at the top of the [`nirspec_pipeline.py`](https://github.com/JWSTGiantPlanets/pipelines/blob/main/nirspec_pipeline.py) file or run `python3 nirspec_pipeline.py --help`.
 
+
+## Point source targets
+These pipelines were originally designed to reduce extended-source solar system targets, but are also able to reduce data for point-source targets. It is worth noting, however, that the steps run after the standard pipeline (`navigate`, `defringe_1d`, `despike`, `psf` etc.) all work with spectral cubes (`*_s3d.fits`), so may not be as useful if you are using extracted 1D spectra (`*_x1d.fits`) instead.
+
+
 ## Support
 If you have any issues running the code in this repository, please [open an issue](https://github.com/JWSTGiantPlanets/pipelines/issues/new) or contact ortk2@leicester.ac.uk.
 

--- a/construct_flat_field.py
+++ b/construct_flat_field.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.3'
+__version__ = '1.1.0'
 
 import datetime
 import math
@@ -265,9 +265,6 @@ def calculate_pixel_ratios(
 def do_tile(
     paths: list[str],
     path_out: str,
-    channel: str,
-    band: str,
-    fringe: str,
     dataset: str,
     *,
     lat_bin_size_factor: float = 1.25,
@@ -278,14 +275,27 @@ def do_tile(
     sigma_iterations: int = 5,
     snr_threshold: float = 10,
     max_correction: float = 1.5,
+    channel: str | None = None,  # MIRI metadata
+    band: str | None = None,
+    fringe: str | None = None,
+    filter: str | None = None,  # NIRSpec metadata
+    grating: str | None = None,
 ):
     header = fits.Header()
     header[f'HIERARCH {HEADER_PREFIX} VERSION'] = (__version__, 'Software version')
     header[f'HIERARCH {HEADER_PREFIX} DATE'] = datetime.datetime.now().isoformat()
     header[f'HIERARCH {HEADER_PREFIX} DATASET'] = dataset
-    header[f'HIERARCH {HEADER_PREFIX} CHANNEL'] = channel
-    header[f'HIERARCH {HEADER_PREFIX} BAND'] = band
-    header[f'HIERARCH {HEADER_PREFIX} DEFRINGED'] = bool(fringe)
+
+    if channel is not None:
+        header[f'HIERARCH {HEADER_PREFIX} CHANNEL'] = channel
+    if band is not None:
+        header[f'HIERARCH {HEADER_PREFIX} BAND'] = band
+    if fringe is not None:
+        header[f'HIERARCH {HEADER_PREFIX} DEFRINGED'] = bool(fringe)
+    if filter is not None:
+        header[f'HIERARCH {HEADER_PREFIX} FILTER'] = filter
+    if grating is not None:
+        header[f'HIERARCH {HEADER_PREFIX} GRATING'] = grating
 
     flat_cube = construct_flat_cube(
         paths,

--- a/construct_flat_field.py
+++ b/construct_flat_field.py
@@ -278,7 +278,7 @@ def do_tile(
     channel: str | None = None,  # MIRI metadata
     band: str | None = None,
     fringe: str | None = None,
-    filter: str | None = None,  # NIRSpec metadata
+    filter_: str | None = None,  # NIRSpec metadata
     grating: str | None = None,
 ):
     header = fits.Header()
@@ -292,8 +292,8 @@ def do_tile(
         header[f'HIERARCH {HEADER_PREFIX} BAND'] = band
     if fringe is not None:
         header[f'HIERARCH {HEADER_PREFIX} DEFRINGED'] = bool(fringe)
-    if filter is not None:
-        header[f'HIERARCH {HEADER_PREFIX} FILTER'] = filter
+    if filter_ is not None:
+        header[f'HIERARCH {HEADER_PREFIX} FILTER'] = filter_
     if grating is not None:
         header[f'HIERARCH {HEADER_PREFIX} GRATING'] = grating
 

--- a/defringe_1d.py
+++ b/defringe_1d.py
@@ -107,7 +107,7 @@ def defringe_file(
         corrected_hdr.add_comment('True values were corrected, False values were not')
         hdul.append(
             fits.ImageHDU(
-                data=corrected_spaxels.astype(int),
+                data=corrected_spaxels.astype(np.uint8),
                 header=corrected_hdr,
                 name='FRINGE1D_CORRECTED',
             )
@@ -144,7 +144,7 @@ def defringe_cube(
     """
     Apply JWST pipeline 1D defringing to each spaxel of a 3D cube independently.
 
-    If a spaxel cannot be corrected (if an erorr is raised while calling the pipeline's
+    If a spaxel cannot be corrected (if an error is raised while calling the pipeline's
     `fit_residual_fringes_1d` function), it will be left unchanged. The returned
     `corrected_spaxels` array can be used to identify which spaxels were corrected.
 

--- a/jwst_summary_plots.py
+++ b/jwst_summary_plots.py
@@ -145,6 +145,10 @@ def make_summary_plot(
             reduction_notes.append('Background subtracted')
         if primary_header.get('S_RESFRI') == 'COMPLETE':
             reduction_notes.append('Residual fringe corrected (2D)')
+        try:
+            reduction_notes.append(f'Cube build weighting: {primary_header["WTYPE"]}')
+        except KeyError:
+            pass
         reduction_notes.extend(get_header_reduction_notes(hdul))
     instrument = primary_header['INSTRUME']
 

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -169,8 +169,8 @@ STEP_DESCRIPTIONS = """
 - `stage1`: Run the standard JWST reduction pipeline stage 1.
 - `stage2`: Run the standard JWST reduction pipeline stage 2 (including optional background subtraction).
 - `defringe`: Run the JWST reduction pipeline 2D residual fringe step (note `defringe_1d` is generally preferred) [optional].
-- `stage3`: Run the standard JWST reduction pipeline stage 3.
-- `defringe_1d`: Run the JWST reduction pipeline 1D residual fringe step [optional].
+- `stage3`: Run the standard JWST reduction pipeline stage 3 (including automatically running the spectral leak step on x1d spectra, if present).
+- `defringe_1d`: Apply the JWST reduction pipeline 1D residual fringe step to each spectrum in the s3d data cubes [optional].
 - `navigate`: Navigate reduced files.
 - `psf`: Correct PSF effects using a forward model convolved with telescope's PSF [optional].
 - `desaturate`: Desaturate data using cubes with fewer groups [optional].
@@ -215,6 +215,7 @@ from typing import Any, Collection
 import tqdm
 from astropy.io import fits
 from jwst.residual_fringe import ResidualFringeStep
+from jwst.spectral_leak import SpectralLeakStep
 
 import argparse_utils
 import flat_field
@@ -224,7 +225,7 @@ from parallel_tools import runmany
 from pipeline import BoolOrBoth, Pipeline, RootPath, Step, get_pipeline_argument_parser
 
 # Pipeline constants for MIRI
-STEPS = (
+STEPS: tuple[Step, ...] = (
     'remove_groups',
     'stage1',
     'stage2',
@@ -249,7 +250,6 @@ DEFAULT_KWARGS: dict[Step, dict[str, Any]] = {
     },
     'stage3': {
         'steps': {
-            'extract_1d': {'skip': True},
             'cube_build': {'output_type': 'band', 'coord_system': 'ifualign'},
         }
     },
@@ -652,6 +652,82 @@ class MiriPipeline(Pipeline):
     def defringe_1d_fn(self, args: tuple[str, str, dict[str, Any]]) -> None:
         p_in, p_out, kwargs = args
         defringe_file(p_in, p_out, **kwargs)
+
+    # stage3+spectral_leak
+    def run_stage3(self, kwargs: dict[str, Any]) -> None:
+        super().run_stage3(kwargs)
+
+        # The spectral leak step needs 3A and 1B to be in the ASN, so manually run it
+        # with all wavelengths in the same ASN. Putting everything in the same ASN for
+        # the whole of stage3 can mess up the WCS info for moving targets, so we only
+        # do it for the spectral leak step.
+        try:
+            spectral_leak_kwargs = kwargs['steps']['spectral_leak']
+        except KeyError:
+            spectral_leak_kwargs = {}
+        self.run_spectral_leak(spectral_leak_kwargs)
+
+    def run_spectral_leak(self, kwargs: dict[str, Any]) -> None:
+        _, dir_in = self.step_directories['stage3']
+        for root_path in self.iterate_group_root_paths():
+            paths_list: list[tuple[str, str]] = []
+            for variant in self.data_variant_combinations:
+                paths_in = self.get_paths(
+                    root_path,
+                    dir_in,
+                    '*',
+                    '*_x1d.fits',
+                    filter_variants=True,
+                    variant_combinations={variant},
+                    do_warning=False,
+                )
+                grouped_files = self.group_x1d_files_for_spectral_leak(paths_in)
+                for (output_dir, prodname), paths_in in grouped_files.items():
+                    asn_path = self.write_asn_for_stage3(
+                        paths_in,
+                        os.path.join(output_dir, f'{prodname}_x1d_asn.json'),
+                        prodname=prodname,
+                    )
+                    paths_list.append((asn_path, output_dir))
+            args_list = [
+                (p, output_dir, kwargs) for p, output_dir in sorted(paths_list)
+            ]
+            if len(args_list) > 0:
+                runmany(
+                    self.spectral_leak_fn,
+                    args_list,
+                    desc='spectral_leak',
+                    **self.reduction_parallel_kwargs,
+                )
+
+    def spectral_leak_fn(self, args: tuple[str, str, dict[str, Any]]) -> None:
+        asn_path, output_dir, kwargs = args
+        container = SpectralLeakStep.call(asn_path, save_results=False, **kwargs)
+        for model in container:
+            # Only save the model if the spectral leak step was actually run
+            if model.meta.cal_step.spectral_leak is not None:
+                path = os.path.join(output_dir, model.meta.filename)
+                with fits.open(path) as hdul:
+                    hdr: fits.Header = hdul['PRIMARY'].header  # type: ignore
+                if hdr.get('S_SPLEAK', None) == 'COMPLETE':
+                    # Ensure that we don't double-apply the spectral leak step
+                    print(
+                        f'WARNING: {path} already has the spectral leak step applied, '
+                        'skipping manual spectral leak step'
+                    )
+                    continue
+                model.save(path)
+
+    def group_x1d_files_for_spectral_leak(
+        self, paths_in: list[str]
+    ) -> dict[tuple[str, str], list[str]]:
+        out: dict[tuple[str, str], list[str]] = {}
+        for p_in in paths_in:
+            p = pathlib.Path(p_in)
+            prodname = '_'.join(p.name.split('_')[:-2])
+            output_dir = str(p.parent)
+            out.setdefault((output_dir, prodname), []).append(p_in)
+        return out
 
     # psf
     def run_psf(self, kwargs: dict[str, Any]) -> None:

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -497,6 +497,10 @@ class MiriPipeline(Pipeline):
         return ()
 
     @property
+    def stage3_file_match_hdr_band_keys(self) -> tuple[str, ...]:
+        return ('CHANNEL', 'BAND')
+
+    @property
     def stage_directories_to_plot(self) -> tuple[str, ...]:
         return STAGE_DIRECTORIES_TO_PLOT
 

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -210,7 +210,7 @@ python3 miri_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outl
 """
 import os
 import pathlib
-from typing import Any, Collection
+from typing import Any, Collection, Literal
 
 import tqdm
 from astropy.io import fits
@@ -305,6 +305,7 @@ def run_pipeline(
     groups_to_use: list[int] | None = None,
     background_subtract: BoolOrBoth = 'both',
     background_path: str | None = None,
+    cube_build_weighting: Literal['drizzle', 'emsm', 'msm'] | None = None,
     basic_navigation: bool = False,
     step_kwargs: dict[Step, dict[str, Any]] | None = None,
     parallel_kwargs: dict[str, Any] | None = None,
@@ -386,6 +387,14 @@ def run_pipeline(
             equivalent of `root_path` for the background observations). Note that the
             background data must be reduced to at least `stage1` for this to work as
             the *_rate.fits files are used for the background subtraction.
+        cube_build_weighting: Weighting algorithm to use when building spectral cubes.
+            This is a convenience argument to set the `weighting` parameter in the
+            `cube_build` step in the `stage3` pipeline, and is equivalent to passing
+            a value with
+            `step_kwargs={'stage3': {'steps': {'cube_build': {'weighting': ...}}}}`.
+            Possible values are 'drizzle' (the default), 'emsm', and 'msm'. See
+            https://jwst-pipeline.readthedocs.io/en/latest/jwst/cube_build/main.html#weighting
+            for more details on the different algorithms.
         basic_navigation: Toggle between basic or full navigation. If True, then only
             RA and Dec navigation backplanes are generated (e.g. useful for small
             bodies). If False (the default), then full navigation is performed,
@@ -439,6 +448,7 @@ def run_pipeline(
         groups_to_use=groups_to_use,
         background_subtract=background_subtract,
         background_path=background_path,
+        cube_build_weighting=cube_build_weighting,
         basic_navigation=basic_navigation,
         step_kwargs=step_kwargs,
         parallel_kwargs=parallel_kwargs,

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -230,8 +230,8 @@ STEPS = (
     'stage2',
     'defringe',
     'stage3',
-    'navigate',
     'defringe_1d',
+    'navigate',
     'psf',
     'desaturate',
     'flat',
@@ -249,7 +249,6 @@ DEFAULT_KWARGS: dict[Step, dict[str, Any]] = {
     },
     'stage3': {
         'steps': {
-            'extract_1d': {'skip': True},
             'cube_build': {'output_type': 'band', 'coord_system': 'ifualign'},
         }
     },
@@ -616,7 +615,7 @@ class MiriPipeline(Pipeline):
                     root_path,
                     dir_in,
                     '*',
-                    '*_nav.fits',
+                    '*_s3d.fits',
                     filter_variants=True,
                     variant_combinations={input_variant},
                 )

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -494,7 +494,7 @@ class MiriPipeline(Pipeline):
 
     @property
     def stage3_file_match_hdr_keys(self) -> tuple[str, ...]:
-        return ('CHANNEL', 'BAND')
+        return ()
 
     @property
     def stage_directories_to_plot(self) -> tuple[str, ...]:

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -249,6 +249,7 @@ DEFAULT_KWARGS: dict[Step, dict[str, Any]] = {
     },
     'stage3': {
         'steps': {
+            'extract_1d': {'skip': True},
             'cube_build': {'output_type': 'band', 'coord_system': 'ifualign'},
         }
     },
@@ -493,10 +494,6 @@ class MiriPipeline(Pipeline):
 
     @property
     def stage3_file_match_hdr_keys(self) -> tuple[str, ...]:
-        return ()
-
-    @property
-    def stage3_file_match_hdr_band_keys(self) -> tuple[str, ...]:
         return ('CHANNEL', 'BAND')
 
     @property

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -170,8 +170,8 @@ STEP_DESCRIPTIONS = """
 - `stage2`: Run the standard JWST reduction pipeline stage 2 (including optional background subtraction).
 - `defringe`: Run the JWST reduction pipeline 2D residual fringe step (note `defringe_1d` is generally preferred) [optional].
 - `stage3`: Run the standard JWST reduction pipeline stage 3.
-- `navigate`: Navigate reduced files.
 - `defringe_1d`: Run the JWST reduction pipeline 1D residual fringe step [optional].
+- `navigate`: Navigate reduced files.
 - `psf`: Correct PSF effects using a forward model convolved with telescope's PSF [optional].
 - `desaturate`: Desaturate data using cubes with fewer groups [optional].
 - `flat`: Correct flat effects using synthetic flat field cubes.

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -190,6 +190,9 @@ python3 miri_pipeline.py /data/uranus/lon1
 # Run the full pipeline, with desaturation
 python3 miri_pipeline.py /data/uranus/lon1 --desaturate
 
+# Run the full pipeline, with emsm weighting when building spectral cubes
+python3 miri_pipeline.py /data/uranus/lon1 --cube-build-weighting=emsm
+
 # Run the full pipeline, with only the defringed data
 python3 miri_pipeline.py /data/uranus/lon1 --defringe_1d
 

--- a/miri_pipeline.py
+++ b/miri_pipeline.py
@@ -668,6 +668,7 @@ class MiriPipeline(Pipeline):
         self.run_spectral_leak(spectral_leak_kwargs)
 
     def run_spectral_leak(self, kwargs: dict[str, Any]) -> None:
+        self.log('Running spectral leak step on any extracted 1D spectra')
         _, dir_in = self.step_directories['stage3']
         for root_path in self.iterate_group_root_paths():
             paths_list: list[tuple[str, str]] = []

--- a/navigate_jwst_observations.py
+++ b/navigate_jwst_observations.py
@@ -70,6 +70,7 @@ KERNEL_NAMES = [
     'jup365.bsp',
     'sat415.bsp',
     'sat425.bsp',
+    'sat441.bsp',
     'ura115.bsp',
     'nep095.bsp',
     'jwst_rec.bsp',

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -199,7 +199,7 @@ python3 nirspec_pipeline.py /data/uranus/lon1 --desaturate --start-step desatura
 # Run the pipeline, passing custom arguments to different steps
 python3 nirspec_pipeline.py /data/uranus/lon1 --kwargs '{"stage3": {"steps": {"outlier_detection": {"snr": "30.0 24.0", "scale": "1.3 0.7"}}}, "plot": {"plot_brightest_spectrum": true}}'
 """
-from typing import Any, Collection
+from typing import Any, Collection, Literal
 
 import tqdm
 from astropy.io import fits
@@ -259,6 +259,7 @@ def run_pipeline(
     groups_to_use: list[int] | None = None,
     background_subtract: BoolOrBoth = 'both',
     background_path: str | None = None,
+    cube_build_weighting: Literal['drizzle', 'emsm', 'msm'] | None = None,
     basic_navigation: bool = False,
     step_kwargs: dict[Step, dict[str, Any]] | None = None,
     parallel_kwargs: dict[str, Any] | None = None,
@@ -337,6 +338,14 @@ def run_pipeline(
             equivalent of `root_path` for the background observations). Note that the
             background data must be reduced to at least `stage1` for this to work as
             the *_rate.fits files are used for the background subtraction.
+        cube_build_weighting: Weighting algorithm to use when building spectral cubes.
+            This is a convenience argument to set the `weighting` parameter in the
+            `cube_build` step in the `stage3` pipeline, and is equivalent to passing
+            a value with
+            `step_kwargs={'stage3': {'steps': {'cube_build': {'weighting': ...}}}}`.
+            Possible values are 'drizzle' (the default), 'emsm', and 'msm'. See
+            https://jwst-pipeline.readthedocs.io/en/latest/jwst/cube_build/main.html#weighting
+            for more details on the different algorithms.
         basic_navigation: Toggle between basic or full navigation. If True, then only
             RA and Dec navigation backplanes are generated (e.g. useful for small
             bodies). If False (the default), then full navigation is performed,
@@ -370,6 +379,7 @@ def run_pipeline(
         groups_to_use=groups_to_use,
         background_subtract=background_subtract,
         background_path=background_path,
+        cube_build_weighting=cube_build_weighting,
         basic_navigation=basic_navigation,
         step_kwargs=step_kwargs,
         parallel_kwargs=parallel_kwargs,

--- a/nirspec_pipeline.py
+++ b/nirspec_pipeline.py
@@ -184,6 +184,9 @@ python3 nirspec_pipeline.py /data/uranus/lon1 --parallel 0.5
 # Run the full pipeline, with desaturation
 python3 nirspec_pipeline.py /data/uranus/lon1 --desaturate
 
+# Run the full pipeline, with emsm weighting when building spectral cubes
+python3 nirspec_pipeline.py /data/uranus/lon1 --cube-build-weighting=emsm
+
 # Run the pipeline, including background subtraction
 python3 nirspec_pipeline.py /data/uranus/lon1 --background-path /data/uranus/background
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -120,6 +120,14 @@ class Pipeline:
             equivalent of `root_path` for the background observations). Note that the
             background data must be reduced to at least `stage1` for this to work as
             the *_rate.fits files are used for the background subtraction.
+        cube_build_weighting: Weighting algorithm to use when building spectral cubes.
+            This is a convenience argument to set the `weighting` parameter in the
+            `cube_build` step in the `stage3` pipeline, and is equivalent to passing
+            a value with
+            `step_kwargs={'stage3': {'steps': {'cube_build': {'weighting': ...}}}}`.
+            Possible values are 'drizzle' (the default), 'emsm', and 'msm'. See
+            https://jwst-pipeline.readthedocs.io/en/latest/jwst/cube_build/main.html#weighting
+            for more details on the different algorithms.
         basic_navigation: Toggle between basic or full navigation. If True, then only
             RA and Dec navigation backplanes are generated (e.g. useful for small
             bodies). If False (the default), then full navigation is performed,
@@ -151,6 +159,7 @@ class Pipeline:
         groups_to_use: list[int] | None | str = None,
         background_subtract: BoolOrBoth = 'both',
         background_path: str | None = None,
+        cube_build_weighting: Literal['drizzle', 'emsm', 'msm'] | None = None,
         basic_navigation: bool = False,
         step_kwargs: dict[Step, dict[str, Any]] | None | str = None,
         parallel_kwargs: dict[str, Any] | None = None,
@@ -181,6 +190,16 @@ class Pipeline:
         self.background_subtract = background_subtract
         self.background_path = self.standardise_path(background_path)
         self.basic_navigation = basic_navigation
+
+        if cube_build_weighting is not None:
+            self.step_kwargs = merge_nested_dicts(
+                self.step_kwargs,
+                {
+                    'stage3': {
+                        'steps': {'cube_build': {'weighting': cube_build_weighting}}
+                    }
+                },
+            )
 
         for k in self.step_kwargs.keys():
             if k not in self.steps:
@@ -1109,6 +1128,18 @@ def get_pipeline_argument_parser(
             require the background data to be already reduced to `stage1`. If no 
             `background-path` is specified (the default), then no background subtraction
             will be performed.""",
+    )
+    parser.add_argument(
+        '--cube-build-weighting',
+        choices=['drizzle', 'emsm', 'msm'],
+        help="""Weighting algorithm to use when building spectral cubes. This is a
+            convenience argument to set the `weighting` parameter in the `cube_build`
+            step in the `stage3` pipeline, and is equivalent to passing a value with
+            `--kwargs '{"stage3": {"steps": {"cube_build": {"weighting": ...}}}}'`.
+            Possible values are 'drizzle' (the default), 'emsm', and 'msm'. See
+            https://jwst-pipeline.readthedocs.io/en/latest/jwst/cube_build/main.html#weighting
+            for more details on the different algorithms.
+            """,
     )
     parser.add_argument(
         '--basic-navigation',

--- a/pipeline.py
+++ b/pipeline.py
@@ -788,7 +788,7 @@ class Pipeline:
                 include_tile_in_prodname = len(keys_with_tiles) != len(
                     keys_without_tiles
                 )
-                
+
                 for (dither, tile, match_key), paths_in in grouped_files.items():
                     dirname = 'combined' if dither is None else f'd{dither}'
                     dirname = dirname + variant_dirname
@@ -882,7 +882,7 @@ class Pipeline:
         Get a key used to match background and science files.
         """
         return self.get_file_match_key(path, self.stage3_file_match_hdr_keys)
-    
+
     def write_asn_for_stage3(
         self, files: list[str], asn_path: str, prodname: str, **kwargs
     ) -> str:

--- a/pipeline.py
+++ b/pipeline.py
@@ -54,11 +54,11 @@ Step: TypeAlias = Literal[
     'navigate',
     'desaturate',
     'despike',
+    'flat',
     'plot',
     'animate',
     'defringe_1d',  # MIRI only
     'psf',  # MIRI only
-    'flat',  # MIRI only
     'defringe',  # MIRI only
 ]
 BoolOrBoth: TypeAlias = Literal[True, False, 'both']

--- a/pipeline.py
+++ b/pipeline.py
@@ -352,10 +352,13 @@ class Pipeline:
 
     @staticmethod
     def standardise_path(path: str | None) -> str | None:
-        """Standardise a path by expanding environment variables and user."""
+        """
+        Standardise a path by expanding environment variables and user, then converting
+        to an absolute path.
+        """
         if path is None:
             return None
-        return os.path.expandvars(os.path.expanduser(path))
+        return os.path.abspath(os.path.expandvars(os.path.expanduser(path)))
 
     @staticmethod
     def replace_path_part(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ profile = "black"
 [tool.pylint.'MESSAGES CONTROL']
 disable = [
     "C",
-    "fixme",
     "no-member",
     "unused-variable",
     "no-else-return",
@@ -29,7 +28,8 @@ disable = [
     "too-few-public-methods",
     "too-many-ancestors",
     "too-many-return-statements",
-    ]
-enable = [
-    "useless-suppression",
-    ]
+]
+enable = ["useless-suppression"]
+
+[tool.pylint.miscellaneous]
+notes = ["FIXME", "XXX"] # Allow TODO comments, but not FIXME or XXX


### PR DESCRIPTION
- Add optional flat field step to NIRSpec pipeline
- Add explicit warning messages when no input paths are found
- Manually run spectral leak step on extracted 1D spectra (`*_x1d.fits`) to ensure it is applied correctly in all cases where it is relevant (i.e. point sources)
- Improve README documentation for point source targets
- Add `--cube-build-weighting` argument to allow weighting to be easily customised, without needing to pass complicated JSON strings to `--kwargs`