### PR TITLE
Fix bug where underscores can be converted to dashes when passed as command line arguments

### DIFF
--- a/argparse_utils.py
+++ b/argparse_utils.py
@@ -20,7 +20,13 @@ class UnderscoreArgumentParser(argparse.ArgumentParser):
         args = list(args)
         for i, arg in enumerate(args):
             if arg.startswith('--'):
-                args[i] = '--' + arg[2:].replace('_', '-')
+                key, value = arg.split('=', 1) if '=' in arg else (arg, None)
+                key = '--' + key[2:].replace('_', '-')
+                if value is None:
+                    arg = key
+                else:
+                    arg = key + '=' + value
+                args[i] = arg
         return super().parse_args(args, namespace)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ disable = [
     "too-few-public-methods",
     "too-many-ancestors",
     "too-many-return-statements",
+    "too-many-positional-arguments",
 ]
 enable = ["useless-suppression"]
 


### PR DESCRIPTION
Fix bug where the `UnderscoreArgumentParser` would convert arguments like `--abc_def=x_y_z` to `--abc-def=x-y-z`, when it is only the argument name that should be converted. With this bugfix, the value remains untouched (e.g. to `--abc-def=x_y_z`).